### PR TITLE
string_concat() para las commons

### DIFF
--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdio.h>
+#include <stdarg.h>
 
 static void string_do(char *text, void (*closure)(char*));
 static void string_lower_element(char* ch);
@@ -65,6 +67,35 @@ char* string_duplicate(char* original) {
 void string_append(char** original, char* string_to_add) {
 	*original = realloc(*original, strlen(*original) + strlen(string_to_add) + 1);
 	strcat(*original, string_to_add);
+}
+
+/**
+ * @NAME: string_concat
+ * @DESC: Concatena al primer string el resultado de aplicar los parametros al
+ * formato especificado
+ *
+ * Ejemplo:
+ * char *saludo = "HOLA ";
+ * char *nombre = "PEPE";
+ *
+ * string_concat(&saludo, "%s!", nombre);
+ *
+ * => saludo = "HOLA PEPE!"
+ */
+void string_concat(char **original, const char *format, ...) {
+    size_t buffer_size = strlen(format) + 1;
+    char *temporal = malloc(buffer_size);
+    size_t message_length = 0;
+    va_list arguments;
+    va_start(arguments, format);
+    while((message_length = vsnprintf(temporal, buffer_size, format, arguments)) > buffer_size - 1) {
+        buffer_size *= 2;
+        temporal = (char *) realloc(temporal, buffer_size);
+    }
+    va_end(arguments);
+    temporal = (char *) realloc(temporal, message_length + 1);
+    
+    string_append(original, temporal);
 }
 
 /**

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -18,9 +18,11 @@
 #define STRING_H_
 
 	#include <stdbool.h>
+	#include <stdarg.h>
 
 	char 	*string_repeat(char ch, int count);
 	void 	string_append(char ** original, char * string_to_add);
+	void    string_concat(char **original, const char *format, ...);
 	char*	string_duplicate(char* original);
 
 	void 	string_to_upper(char * text);


### PR DESCRIPTION
`string_concat()` recibe un string, un formato y una lista de argumentos variables, y `string_append`ea el resultado de aplicar los argumentos al formato al string original.

La desarrollé para el TP, tal vez otro se ahorra un rato de laburo si tiene esto ya hecho.

Quiero creer que no tiene errores de memoria, pero debería revisar más exhaustivamente con valgrind, tal vez.
