### PR TITLE
Agrego #string_substring

### DIFF
--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -259,6 +259,16 @@ char **string_split(char *text, char *separator) {
 }
 
 /**
+ * @NAME: string_substring
+ * @DESC: Retorna un string nuevo a partir de la longitud dada
+ */
+char*   string_substring(char* text, int length) {
+	char* new_string = calloc(1, length + 1);
+	strncpy(new_string, text, length);
+	return new_string;
+}
+
+/**
  * @NAME: string_iterate_lines
  * @DESC: Itera un array de strings aplicando
  * el closure a cada string

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef STRING_H_
-#define STRING_H_
+#ifndef STRING_UTILS_H_
+#define STRING_UTILS_H_
 
 	#include <stdbool.h>
 	#include <stdarg.h>
@@ -40,7 +40,8 @@
 	bool	string_ends_with(char* text, char* end);
 	bool 	string_equals_ignore_case(char * actual, char * expected);
 	char**  string_split(char * text, char * separator);
+	char*   string_substring(char* text, int length);
 
 	void 	string_iterate_lines(char ** strings, void (*closure)(char *));
 
-#endif /* STRING_H_ */
+#endif /* STRING_UTILS_H_ */

--- a/tests/test_string.c
+++ b/tests/test_string.c
@@ -207,6 +207,38 @@ static void test_string_ends_with() {
 	CU_ASSERT_FALSE(string_ends_with("", "txt"));
 }
 
+static void test_string_substring_empty() {
+	char* original_word = "";
+	char* substring = string_substring(original_word, 3);
+	CU_ASSERT_STRING_EQUAL(substring, original_word);
+	CU_ASSERT_PTR_NOT_EQUAL(substring, original_word);
+	free(substring);
+}
+
+static void test_string_substring_with_short_string() {
+	char* original_word = "hola";
+	char* substring = string_substring(original_word, 14);
+	CU_ASSERT_STRING_EQUAL(substring, original_word);
+	CU_ASSERT_PTR_NOT_EQUAL(substring, original_word);
+	free(substring);
+}
+
+static void test_string_substring_with_large_string() {
+	char* original_word = "hola mundo c!";
+	char* substring = string_substring(original_word, 4);
+	CU_ASSERT_STRING_EQUAL(substring, "hola");
+	CU_ASSERT_PTR_NOT_EQUAL(substring, original_word);
+	free(substring);
+}
+
+static void test_string_substring_with_equal_large() {
+	char* original_word = "hola";
+	char* substring = string_substring(original_word, 4);
+	CU_ASSERT_STRING_EQUAL(substring, original_word);
+	CU_ASSERT_PTR_NOT_EQUAL(substring, original_word);
+	free(substring);
+}
+
 /**********************************************************************************************
  *  							Building the test for CUnit
  *********************************************************************************************/
@@ -227,6 +259,10 @@ static CU_TestInfo tests[] = {
 		{ "Test split a string", test_string_split},
 		{ "Test string begin with", test_string_starts_with},
 		{ "Test string ends with", test_string_ends_with},
+		{ "Test string substring with a empty string", test_string_substring_empty},
+		{ "Test string substring with a short string", test_string_substring_with_short_string},
+		{ "Test string substring with a large string", test_string_substring_with_large_string},
+		{ "Test string substring with a equal size", test_string_substring_with_equal_large},
 		CU_TEST_INFO_NULL,
 };
 


### PR DESCRIPTION
Aunque exista strncpy(..) que copia como maximo el largo indicado, no resuelve la problema de alocar memoria. 
Esta funcion se crea para poder realizar las dos cosas, alocar memoria y acortar un string.
