### PR TITLE
Agrego config_get_array_value(..), fixed #19

### DIFF
--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -104,10 +104,33 @@ long config_get_long_value(t_config *self, char *key) {
  * @NAME: config_get_double_value
  * @DESC:Retorna un double con el valor asociado a key.
 */
-
 double config_get_double_value(t_config *self, char *key) {
 	char *value = config_get_string_value(self, key);
 	return atof(value);
+}
+
+/*
+ * @NAME: config_get_array_value
+ * @DESC: Retorna un array con los valores asociados a la key especificada.
+ * En el archivo de configuracion un valor de este tipo debería ser representado
+ * de la siguiente forma [lista_valores_separados_por_coma]
+ * Ejemplo:
+ * VALORES=[1,2,3,4,5]
+*/
+char** config_get_array_value(t_config* self, char* key) {
+	char* value_in_dictionary = config_get_string_value(self, key);
+	int length_value = strlen(value_in_dictionary);
+	char* value_without_brackets = string_substring(value_in_dictionary + 1, length_value - 2);
+	char **array_values = string_split(value_without_brackets, ",");
+
+	int i = 0;
+	while (array_values[i] != NULL) {
+		string_trim(array_values + i);
+		i++;
+	}
+
+	free(value_without_brackets);
+	return array_values;
 }
 
 /*

--- a/src/commons/config.h
+++ b/src/commons/config.h
@@ -30,6 +30,7 @@
 	int 	  config_get_int_value(t_config*, char *key);
 	long	  config_get_long_value(t_config*, char *key);
 	double 	  config_get_double_value(t_config*, char *key);
+	char**    config_get_array_value(t_config*, char* key);
 	int 	  config_keys_amount(t_config*);
 	void 	  config_destroy(t_config *config);
 

--- a/tests/resources/config.cfg
+++ b/tests/resources/config.cfg
@@ -7,3 +7,9 @@ PROCESS_NAME=TEST
 
 # This is the load
 LOAD=0.5
+
+
+# This is an array
+NUMBERS=[1, 2, 3, 4, 5]
+
+EMPTY_ARRAY=[]

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -17,8 +17,13 @@
 #include <commons/config.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
+#include <commons/string.h>
 
 #include "cunit_tools.h"
+
+
+#define KEYS_AMOUNT 6
+#define PATH_CONFIG "tests/resources/config.cfg"
 
 static int init_suite() {
 	return 0;
@@ -29,9 +34,9 @@ static int clean_suite() {
 }
 
 void test_read_config() {
-	t_config* config = config_create("tests/resources/config.cfg");
+	t_config* config = config_create(PATH_CONFIG);
 
-	CU_ASSERT_EQUAL(config_keys_amount(config), 4);
+	CU_ASSERT_EQUAL(config_keys_amount(config), KEYS_AMOUNT);
 
 	CU_ASSERT_TRUE(config_has_property(config, "IP"));
 	CU_ASSERT_STRING_EQUAL(config_get_string_value(config, "IP"), "127.0.0.1");
@@ -45,12 +50,55 @@ void test_read_config() {
 	config_destroy(config);
 }
 
+void test_read_empty_array() {
+	t_config* config = config_create(PATH_CONFIG);
+
+	CU_ASSERT_EQUAL(config_keys_amount(config), KEYS_AMOUNT);
+
+	CU_ASSERT_TRUE(config_has_property(config, "EMPTY_ARRAY"));
+	CU_ASSERT_STRING_EQUAL(config_get_string_value(config, "EMPTY_ARRAY"), "[]");
+
+	char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
+	CU_ASSERT_PTR_NOT_NULL(empty_array);
+	CU_ASSERT_PTR_EQUAL(empty_array[0], NULL);
+
+	string_iterate_lines(empty_array, (void*) free);
+	free(empty_array);
+	config_destroy(config);
+}
+
+void test_read_full_array() {
+	t_config* config = config_create(PATH_CONFIG);
+
+	CU_ASSERT_EQUAL(config_keys_amount(config), KEYS_AMOUNT);
+
+	CU_ASSERT_TRUE(config_has_property(config, "NUMBERS"));
+	CU_ASSERT_STRING_EQUAL(config_get_string_value(config, "NUMBERS"), "[1, 2, 3, 4, 5]");
+
+	char** numeros = config_get_array_value(config, "NUMBERS");
+	CU_ASSERT_PTR_NOT_NULL(numeros);
+	CU_ASSERT_PTR_EQUAL(numeros[5], NULL);
+
+	int i;
+	for (i = 1; i <= 5; ++i) {
+		char* value = string_from_format("%d", i);
+		CU_ASSERT_STRING_EQUAL(numeros[i - 1], value);
+		free(value);
+	}
+
+	string_iterate_lines(numeros, (void*) free);
+	free(numeros);
+	config_destroy(config);
+}
+
 /**********************************************************************************************
  *  							Building the test for CUnit
  *********************************************************************************************/
 
 static CU_TestInfo tests[] = {
 		{ "Test read config", test_read_config },
+		{ "Test read config - with empty array", test_read_empty_array },
+		{ "Test read config - array with values", test_read_full_array },
 		CU_TEST_INFO_NULL };
 
 CUNIT_MAKE_SUITE(config, "Test Config TAD", init_suite, clean_suite, tests)


### PR DESCRIPTION
Permite obtener un array como valor de una clave del archivo config.

Ejemplo:
Numeros = [1,2,3]

Va a devolver un array con los strings "1","2" y "3"
