### PR TITLE
config_create devuelve NULL si no se puede abrir el path

### DIFF
--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -24,38 +24,39 @@
 #include "collections/dictionary.h"
 
 t_config *config_create(char *path) {
+	FILE* file = fopen(path, "r");
+
+	if (file == NULL) {
+		return NULL;
+	}
+
+	struct stat stat_file;
+	stat(path, &stat_file);
+
 	t_config *config = malloc(sizeof(t_config));
 
 	config->path = strdup(path);
 	config->properties = dictionary_create();
 
-	struct stat stat_file;
-	stat(path, &stat_file);
-	FILE* file = NULL;
+	char* buffer = calloc(1, stat_file.st_size + 1);
+	fread(buffer, stat_file.st_size, 1, file);
 
-	file = fopen(path, "r");
+	char** lines = string_split(buffer, "\n");
 
-	if (file != NULL) {
-		char* buffer = calloc(1, stat_file.st_size + 1);
-		fread(buffer, stat_file.st_size, 1, file);
-
-		char** lines = string_split(buffer, "\n");
-
-		void add_cofiguration(char *line) {
-			if (!string_starts_with(line, "#")) {
-				char** keyAndValue = string_split(line, "=");
-				dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
-				free(keyAndValue[0]);
-				free(keyAndValue);
-			}
+	void add_cofiguration(char *line) {
+		if (!string_starts_with(line, "#")) {
+			char** keyAndValue = string_split(line, "=");
+			dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
+			free(keyAndValue[0]);
+			free(keyAndValue);
 		}
-		string_iterate_lines(lines, add_cofiguration);
-		string_iterate_lines(lines, (void*) free);
-
-		free(lines);
-		free(buffer);
-		fclose(file);
 	}
+	string_iterate_lines(lines, add_cofiguration);
+	string_iterate_lines(lines, (void*) free);
+
+	free(lines);
+	free(buffer);
+	fclose(file);
 
 	return config;
 }
@@ -97,3 +98,4 @@ void config_destroy(t_config *config) {
 	free(config->path);
 	free(config);
 }
+

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -32,60 +32,73 @@ context (test_config) {
 
     describe("Config") {
 
-        t_config* config;
+        describe ("Inexistent file") {
 
-        before {
-            config = config_create("resources/config.cfg");
-        } end
-
-        after {
-            config_destroy(config);
-        } end
-
-        it("should return true if has property") {
-            should_bool(config_has_property(config, "NUMBERS")) be truthy;
-        } end
-
-        it("should return false if has not got property") {
-            should_bool(config_has_property(config, "PROPERY_MISSING")) be falsey;
-        } end
-
-        it("should return the keys count") {
-            should_int(config_keys_amount(config)) be equal to(6);
-        } end
-
-        describe("Get") {
-
-            it ("should get int value") {
-                should_int(config_get_int_value(config, "PORT")) be equal to(8080);
+            it ("should return null when try to open a non-existent config file") {
+            	t_config *config = config_create("this_doesnt_exist.really.dont.cfg");
+                should_ptr(config) be null;
             } end
 
-            it ("should get string value") {
-                should_string(config_get_string_value(config, "IP")) be equal to("127.0.0.1");
+        } end
+
+		describe ("Existent file") {
+
+        	t_config* config;
+
+            before {
+                config = config_create("resources/config.cfg");
             } end
 
-            it ("should get double value") {
-                should_double(config_get_double_value(config, "LOAD")) be equal to (0.5);
+            after {
+                config_destroy(config);
             } end
 
-            it ("should get an empty array value") {
-                should_string(config_get_string_value(config, "EMPTY_ARRAY")) be equal to("[]");
-                char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
-
-                char* empty_array_expected[] = {NULL};
-                _assert_equals_array(empty_array_expected, empty_array, 0);
-                free(empty_array);
+            it("should return true if has property") {
+                should_bool(config_has_property(config, "NUMBERS")) be truthy;
             } end
 
-            it ("should get an array with values") {
-                char* numbers_expected[] = {"1", "2", "3", "4", "5", NULL};
-                should_string(config_get_string_value(config, "NUMBERS")) be equal to("[1, 2, 3, 4, 5]");
+            it("should return false if has not got property") {
+                should_bool(config_has_property(config, "PROPERY_MISSING")) be falsey;
+            } end
 
-                char** numbers = config_get_array_value(config, "NUMBERS");
-                _assert_equals_array(numbers_expected, numbers, 5);
+            it("should return the keys count") {
+                should_int(config_keys_amount(config)) be equal to(6);
+            } end
 
-                string_iterate_lines(numbers, (void*) free);
-                free(numbers);
+            describe("Get") {
+
+                it ("should get int value") {
+                    should_int(config_get_int_value(config, "PORT")) be equal to(8080);
+                } end
+
+                it ("should get string value") {
+                    should_string(config_get_string_value(config, "IP")) be equal to("127.0.0.1");
+                } end
+
+                it ("should get double value") {
+                    should_double(config_get_double_value(config, "LOAD")) be equal to (0.5);
+                } end
+
+                it ("should get an empty array value") {
+                    should_string(config_get_string_value(config, "EMPTY_ARRAY")) be equal to("[]");
+                    char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
+
+                    char* empty_array_expected[] = {NULL};
+                    _assert_equals_array(empty_array_expected, empty_array, 0);
+                    free(empty_array);
+                } end
+
+                it ("should get an array with values") {
+                    char* numbers_expected[] = {"1", "2", "3", "4", "5", NULL};
+                    should_string(config_get_string_value(config, "NUMBERS")) be equal to("[1, 2, 3, 4, 5]");
+
+                    char** numbers = config_get_array_value(config, "NUMBERS");
+                    _assert_equals_array(numbers_expected, numbers, 5);
+
+                    string_iterate_lines(numbers, (void*) free);
+                    free(numbers);
+                } end
+
             } end
 
         } end


### PR DESCRIPTION
Si `config_create` no puede abrir el path, devuelve `NULL` para que el usuario pueda saber si la creacion del t_config fue exitosa o no.

Creo que en algún momento lo habíamos discutido con @gastonprieto, no recuerdo si él tenía motivos para _no_ hacerlo, o si simplemente no lo habíamos hecho por fiaca.

Me inspiré por [este thread](http://www.campusvirtual.frba.utn.edu.ar/especialidad/mod/forum/discuss.php?d=34130) en el que hablaban entre @alkchofa y @janopn