### PR TITLE
cambio en  list_remove_and_destroy_element()

### DIFF
--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -141,7 +141,7 @@ void* list_remove_by_condition(t_list *self, bool(*condition)(void*)) {
 
 void list_remove_and_destroy_element(t_list *self, int index, void(*element_destroyer)(void*)) {
 	void* data = list_remove(self, index);
-	element_destroyer(data);
+	if(data)element_destroyer(data);//ya que sino el element_destroyer puede recibir un NULL
 }
 
 void list_remove_and_destroy_by_condition(t_list *self, bool(*condition)(void*), void(*element_destroyer)(void*)) {


### PR DESCRIPTION
Habría que agregarle un if ahí ya que list_remove puede devolver NULL en el caso que nadie cumpla la condición y mandar al element_destroyer un NULL no es muy copado ya que a todos los element_destroyer que se codifiquen habría que meter un if adentro y si es NULL que no haga nada. En este caso poniendo el if(data) si data es NULL(cero) no va a entrar al if y no va a destruir lo que no existe. Y si no NULL hace lo mismo que antes.