### PR TITLE
TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c
+compiler: gcc
+
+before_install: cd tests/unit-tests/
+install: make install-cspec
+
+script: make test
+
+branches:
+  only: master
+
+notifications:
+  email:
+    - gastonprietoutn@gmail.com
+    - mngi0410@gmail.com
+    - J@florius.com.ar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Commons Library For C ##
 
-[![Build Status](https://drone.io/github.com/sisoputnfrba/so-commons-library/status.png)](https://drone.io/github.com/sisoputnfrba/so-commons-library/latest)
+[![Build Status](https://travis-ci.org/sisoputnfrba/so-commons-library.svg?branch=master)](https://travis-ci.org/sisoputnfrba/so-commons-library)
 
 Biblioteca con TADs útiles para el desarrollo de aplicaciones hechas con el lenguaje C
 

--- a/tests/unit-tests/makefile
+++ b/tests/unit-tests/makefile
@@ -27,9 +27,11 @@ clean:
 test: all
 	LD_LIBRARY_PATH="../../src/build/:$(C_SPEC_BIN)" build/commons-unit-test
 
-dependents:
-	-cd ../../ && git submodule init && git submodule update
-	-cd ../../cspec && $(MAKE) all
+dependents: install-cspec
 	-cd ../../src/ && $(MAKE) all
 
-.PHONY: all create-dirs clean
+install-cspec:
+	-cd ../../ && git submodule init && git submodule update
+	-cd ../../cspec && $(MAKE) all
+
+.PHONY: all create-dirs clean install-cspec


### PR DESCRIPTION
TravisCI se integra con GitHub mostrando el estado del build en cada push - bastante util a la hora de evaluar si mergear o no un PR.

Drone sigue prendido, no creo que me moleste que este ahi, pero tener a Travis opinando esta bueno.

CC: @gastonprieto @mdumrauf
Related: #40