### PR TITLE
Halt string_split tokenization if there are no more tokens

### DIFF
--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -254,6 +254,9 @@ char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) 
 
 	while(condition(next, size)) {
 		char* token = strtok_r(str, separator, &next);
+		if(token == NULL) {
+			break;
+		}
 		str = NULL;
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);

--- a/tests/unit-tests/resources/config-double-newline.cfg
+++ b/tests/unit-tests/resources/config-double-newline.cfg
@@ -1,0 +1,17 @@
+# This is the IP
+IP=127.0.0.1
+
+PORT=8080
+
+PROCESS_NAME=TEST
+
+# This is the load
+LOAD=0.5
+
+
+# This is an array
+NUMBERS=[1, 2, 3, 4, 5]
+
+EMPTY_ARRAY=[]
+
+

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -105,4 +105,12 @@ context (test_config) {
 
     } end
 
+    describe("Double newline") {
+
+        it ("should not fail when the config file ends with two newlines") {
+            t_config *config = config_create("resources/config-double-newline.cfg");
+            config_destroy(config);
+        } end
+    } end
+
 }


### PR DESCRIPTION
Parece que #56 en realidad venía porque `string_split` pincha cuando el texto termina con el token.

Quizá habría que hacer algún spec más sobre ese caso en particular.

CC: @gastonprieto
