### PR TITLE
Store element->next before closure on list_iterate

### DIFF
--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -101,9 +101,11 @@ void* list_find(t_list *self, bool(*condition)(void*)) {
 
 void list_iterate(t_list* self, void(*closure)(void*)) {
 	t_link_element *element = self->head;
+	t_link_element *aux = NULL;
 	while (element != NULL) {
+		aux = element->next;
 		closure(element->data);
-		element = element->next;
+		element = aux;
 	}
 }
 


### PR DESCRIPTION
Before calling closure() on list_iterate(), the element->next can be saved in an aux variable, so if the element is removed (using either remove by condition or destroy), the iteration still works.