### PR TITLE
Corregir el prototipo de string_contains

### DIFF
--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -210,7 +210,7 @@ char* string_reverse(char* palabra) {
     return resultado;
 }
 
-char*	string_contains(char* text, char *substring) {
+bool	string_contains(char* text, char *substring) {
 	return strstr(text, substring) != NULL;
 }
 

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -247,6 +247,6 @@
 	 * @DESC: Retorna un boolean que indica si text contiene o no
 	 * a substring.
 	 */
-	char*	string_contains(char* text, char *substring);
+	bool	string_contains(char* text, char *substring);
 
 #endif /* STRING_UTILS_H_ */


### PR DESCRIPTION
Ya devolvía un bool, pero decía devolver un string.
Fixes #92
Gracias @gerosamore!