### PR TITLE
added leak checks in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: c
 compiler: gcc
 
-before_install: cd tests/unit-tests/
+before_install:
+        - sudo apt-get install -y valgrind
+        - cd tests/unit-tests/
 install: make install-cspec
 
 script: make valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler: gcc
 before_install: cd tests/unit-tests/
 install: make install-cspec
 
-script: make test
+script: make valgrind
 
 branches:
   only: master

--- a/makefile
+++ b/makefile
@@ -18,3 +18,6 @@ install: test
 
 uninstall:
 	-cd src && $(MAKE) uninstall
+
+valgrind: all
+	-cd tests/unit-tests && $(MAKE) valgrind

--- a/tests/unit-tests/makefile
+++ b/tests/unit-tests/makefile
@@ -34,4 +34,7 @@ install-cspec:
 	-cd ../../ && git submodule init && git submodule update
 	-cd ../../cspec && $(MAKE) all
 
-.PHONY: all create-dirs clean install-cspec
+valgrind: all
+	LD_LIBRARY_PATH="../../src/build/:$(C_SPEC_BIN)" valgrind --error-exitcode=42 --leak-check=full -v ./build/commons-unit-test
+
+.PHONY: all create-dirs clean install-cspec valgrind


### PR DESCRIPTION
Se cambia para que no pase el build de travis si hay algún memory leak.

(Lo robé de [acá](https://github.com/open-source-parsers/jsoncpp/pull/265))
![image](https://user-images.githubusercontent.com/5218239/36731613-1a5a020c-1baa-11e8-9041-c3e0a388b89b.png)
