### PR TITLE
TAD Vector (aka array redimensionable)

### DIFF
--- a/src/commons/collections/vector.c
+++ b/src/commons/collections/vector.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2019 Sistemas Operativos - UTN FRBA. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "vector.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+void _vector_of_strings_free_fn(void* pstr)
+{
+    char** string = pstr;
+    free(*string);
+}
+
+inline static void* _calculateOffset(void* array, size_t pos, size_t elemSize)
+{
+    return ((char*) array) + pos * elemSize;
+}
+
+inline static size_t _calculateGrowth(vector const* v, size_t newSize)
+{
+    size_t geometric = v->Capacity + v->Capacity / 2;
+    if (geometric < newSize)
+        return newSize;
+    return geometric;
+}
+
+void vector_construct(vector* v, size_t elementSize, VectorFreeFn freeFn, size_t initialCapacity)
+{
+    v->Elements = NULL;
+    v->ElemSize = elementSize;
+    v->Size = 0;
+    v->Capacity = initialCapacity;
+    if (initialCapacity)
+        v->Elements = malloc(initialCapacity * elementSize);
+    v->FreeFn = freeFn;
+}
+
+size_t vector_size(vector const* v)
+{
+    return v->Size;
+}
+
+void vector_resize(vector* v, size_t n, void const* elem)
+{
+    size_t oldsize = v->Size;
+
+    if (n < oldsize)
+        vector_erase_range(v, n, v->Size);
+    else if (n > oldsize)
+    {
+        vector_reserve(v, n);
+
+        // fill rest with elem
+        vector_insert_fill(v, oldsize, n - oldsize, elem);
+    }
+}
+
+void vector_resize_zero(vector* v, size_t n)
+{
+    size_t oldsize = v->Size;
+    if (n < oldsize)
+        vector_erase_range(v, n, v->Size);
+    else
+    {
+        vector_reserve(v, n);
+
+        memset(_calculateOffset(v->Elements, oldsize, v->ElemSize), 0, (n - oldsize) * v->ElemSize);
+        v->Size = n;
+    }
+}
+
+size_t vector_capacity(vector const* v)
+{
+    return v->Capacity;
+}
+
+bool vector_empty(vector const* v)
+{
+    return !v->Size;
+}
+
+void vector_reserve(vector* v, size_t n)
+{
+    if (n <= v->Capacity)
+        return;
+
+    v->Elements = realloc(v->Elements, n * v->ElemSize);
+    v->Capacity = n;
+}
+
+void vector_shrink_to_fit(vector* v)
+{
+    if (v->Capacity == v->Size)
+        return;
+
+    if (!v->Size)
+    {
+        free(v->Elements);
+        v->Elements = NULL;
+        v->Capacity = 0;
+    }
+    else
+    {
+        v->Elements = realloc(v->Elements, v->Size * v->ElemSize);
+        v->Capacity = v->Size;
+    }
+}
+
+void* vector_at(vector const* v, size_t i)
+{
+    assert(v->Elements && i < v->Size);
+    return _calculateOffset(v->Elements, i, v->ElemSize);
+}
+
+void* vector_front(vector const* v)
+{
+    assert(v->Elements);
+    return _calculateOffset(v->Elements, 0, v->ElemSize);
+}
+
+void* vector_back(vector const* v)
+{
+    assert(v->Elements && v->Size);
+    return vector_at(v, v->Size - 1);
+}
+
+void* vector_data(vector const* v)
+{
+    return v->Elements;
+}
+
+void vector_push_back(vector* v, void const* elem)
+{
+    if (v->Capacity == v->Size)
+        vector_reserve(v, _calculateGrowth(v, v->Size + 1));
+
+    memcpy(_calculateOffset(v->Elements, v->Size, v->ElemSize), elem, v->ElemSize);
+    ++v->Size;
+}
+
+void vector_pop_back(vector* v)
+{
+    assert(v->Size);
+    vector_erase(v, v->Size - 1);
+}
+
+void vector_insert(vector* v, size_t pos, void const* elem)
+{
+    vector_insert_fill(v, pos, 1, elem);
+}
+
+void vector_insert_fill(vector* v, size_t pos, size_t n, void const* elem)
+{
+    assert(pos <= v->Size);
+    if (n == 1 && pos == v->Size) // special case
+    {
+        vector_push_back(v, elem);
+        return;
+    }
+
+    if (n > (v->Capacity - v->Size))
+        vector_reserve(v, _calculateGrowth(v, v->Size + n));
+
+    void* start = _calculateOffset(v->Elements, pos, v->ElemSize);
+    void* end = _calculateOffset(v->Elements, pos + n, v->ElemSize);
+    size_t const blockSize = (v->Size - pos) * v->ElemSize;
+
+    memmove(end, start, blockSize);
+    for (size_t i = 0; i < n; ++i)
+        memcpy(_calculateOffset(start, i, v->ElemSize), elem, v->ElemSize);
+    v->Size += n;
+}
+
+void vector_insert_range(vector* v, size_t pos, void* begin, void* end)
+{
+    assert(pos <= v->Size);
+    if (begin == end)
+        return;
+
+    size_t n = ((char*)end - (char*)begin) / v->ElemSize;
+    if (n == 1 && pos == v->Size) // special case
+    {
+        vector_push_back(v, begin);
+        return;
+    }
+
+    if (n > (v->Capacity - v->Size))
+        vector_reserve(v, _calculateGrowth(v, v->Size + n));
+
+    void* shiftSrc = _calculateOffset(v->Elements, pos, v->ElemSize);
+    void* shiftDst = _calculateOffset(v->Elements, pos + n, v->ElemSize);
+    size_t const blockSize = (v->Size - pos) * v->ElemSize;
+
+    if (blockSize)
+        memmove(shiftDst, shiftSrc, blockSize);
+
+    memcpy(shiftSrc, begin, n * v->ElemSize);
+    v->Size += n;
+}
+
+void vector_erase(vector* v, size_t pos)
+{
+    assert(pos < v->Size);
+    vector_erase_range(v, pos, pos + 1);
+}
+
+void vector_erase_range(vector* v, size_t begin, size_t end)
+{
+    assert(begin < v->Size);
+    assert(end <= v->Size);
+
+    size_t n = end - begin;
+    if (v->FreeFn)
+    {
+        for (size_t i = begin; i < end; ++i)
+            v->FreeFn(_calculateOffset(v->Elements, i, v->ElemSize));
+    }
+
+    // shift needed
+    if (end < v->Size)
+    {
+        void* shiftSrc = _calculateOffset(v->Elements, end, v->ElemSize);
+        void* shiftDst = _calculateOffset(v->Elements, begin, v->ElemSize);
+        size_t const blockSize = (v->Size - end) * v->ElemSize;
+        memmove(shiftDst, shiftSrc, blockSize);
+    }
+
+    v->Size -= n;
+}
+
+void vector_swap(vector* v, vector* other)
+{
+    //POD should copy
+    vector me = *v;
+    *v = *other;
+    *other = me;
+}
+
+void vector_clear(vector* v)
+{
+    if (v->FreeFn)
+        vector_iterate(v, v->FreeFn);
+    v->Size = 0;
+}
+
+void vector_iterate(vector const* v, VectorClosureFn closureFn)
+{
+    for (size_t i = 0; i < v->Size; ++i)
+        closureFn(_calculateOffset(v->Elements, i, v->ElemSize));
+}
+
+void vector_destruct(vector* v)
+{
+    if (v->FreeFn)
+        vector_iterate(v, v->FreeFn);
+    free(v->Elements);
+}

--- a/src/commons/collections/vector.h
+++ b/src/commons/collections/vector.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2019 Sistemas Operativos - UTN FRBA. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef vector_h__
+#define vector_h__
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * Función de liberación de elemento (free o similar)
+ */
+typedef void (*VectorFreeFn)(void* element);
+
+/*
+ * Función que recorre elementos
+ */
+typedef void (*VectorClosureFn)(void* element);
+
+typedef struct
+{
+    void* Elements;
+    size_t ElemSize;
+    size_t Size;
+    size_t Capacity;
+    VectorFreeFn FreeFn;
+} vector;
+
+/*
+ * Inicializador estático (à la pthreads) para la muy utilizada abstracción "vector de strings"
+ */
+void _vector_of_strings_free_fn(void* pstr);
+
+#define VECTOR_OF_STRINGS_INITIALIZER \
+    { NULL, sizeof(char*), 0, 0, _vector_of_strings_free_fn }
+
+/**
+ * @NAME: vector_construct
+ * @DESC: Construye un nuevo vector in-place
+ * elementSize: tamaño de los elementos que guardara el vector normalmente sizeof(tipo-elemento)
+ * freeFn: funcion llamada para destruir los elementos en sí, si es distinta a NULL 
+ * initialCapacity: reserva inicial de memoria para guardar 'initialCapacity' elementos (puede ser 0)
+ */
+void vector_construct(vector* v, size_t elementSize, VectorFreeFn freeFn, size_t initialCapacity);
+
+/**
+ * @NAME: vector_destruct
+ * @DESC: Libera la memoria reservada por las estructuras
+ * destruyendo los elementos con la funcion pasada como parametro al construir, si no es NULL
+ */
+void vector_destruct(vector* v);
+
+// C++ like interface
+
+/**
+ * @NAME: vector_size
+ * @DESC: Devuelve tamaño del vector
+ */
+size_t vector_size(vector const* v);
+
+/**
+ * @NAME: vector_resize
+ * @DESC: Cambia el tamaño del vector eliminando o insertando elementos
+ * Los elementos insertados serán copias del elemento pasado por parámetro
+ */
+void vector_resize(vector* v, size_t n, void const* elem);
+
+/**
+ * @NAME: vector_resize_zero
+ * @DESC: Cambia el tamaño del vector eliminando o insertando elementos
+ * Los elementos insertados serán inicializados en 0
+ */
+void vector_resize_zero(vector* v, size_t n);
+
+/**
+ * @NAME: vector_capacity
+ * @DESC: Devuelve capacidad actual de elementos
+ */
+size_t vector_capacity(vector const* v);
+
+/**
+ * @NAME: vector_empty
+ * @DESC: Devuelve true ssi el vector está vacio
+ */
+bool vector_empty(vector const* v);
+
+/**
+ * @NAME: vector_reserve
+ * @DESC: Se asegura que la capacidad alocada sea de al menos n elementos
+ * No cambia ningún elemento actual
+ */
+void vector_reserve(vector* v, size_t n);
+
+/**
+ * @NAME: vector_shrink_to_fit
+ * @DESC: Encoge la capacidad del vector de forma tal que sólo quepan
+ * sus elementos actuales. A diferencia del estándar, siempre efectúa la operación
+ * en caso de ser necesaria.
+ */
+void vector_shrink_to_fit(vector* v);
+
+/**
+ * @NAME: vector_at
+ * @DESC: Devuelve el elemento en la posición i-ésima.
+ */
+void* vector_at(vector const* v, size_t i);
+
+/**
+ * @NAME: vector_front
+ * @DESC: Devuelve el primer elemento
+ */
+void* vector_front(vector const* v);
+
+/**
+ * @NAME: vector_back
+ * @DESC: Devuelve el último elemento
+ */
+void* vector_back(vector const* v);
+
+/**
+ * @NAME: vector_data
+ * @DESC: Devuelve el arreglo de datos
+ */
+void* vector_data(vector const* v);
+
+/**
+ * @NAME: vector_push_back
+ * @DESC: Inserta un elemento al final
+ */
+void vector_push_back(vector* v, void const* elem);
+
+/**
+ * @NAME: vector_pop_back
+ * @DESC: Elimina el último elemento
+ */
+void vector_pop_back(vector* v);
+
+/**
+ * @NAME; vector_insert
+ * @DESC: Inserta un único valor en la posición 'pos'
+ */
+void vector_insert(vector* v, size_t pos, void const* elem);
+
+/**
+ * @NAME: vector_insert_fill
+ * @DESC: Inserta n copias del elemento elem a partir de la posición 'pos'
+ */
+void vector_insert_fill(vector* v, size_t pos, size_t n, void const* elem);
+
+/**
+ * @NAME: vector_insert_range
+ * @DESC: Inserta valores desde un arreglo, entre la posicion begin, hasta la end exclusive
+ * En otras palabras, rango cerrado abierto [begin, end)
+ */
+void vector_insert_range(vector* v, size_t pos, void* begin, void* end);
+
+/**
+ * @NAME: vector_erase
+ * @DESC: Borra el elemento ubicado en 'pos'
+ */
+void vector_erase(vector* v, size_t pos);
+
+/**
+ * @NAME: vector_erase_range
+ * @DESC: Borra los elementos en el rango de posiciones cerrado abierto [begin, end)
+ */
+void vector_erase_range(vector* v, size_t begin, size_t end);
+
+/**
+ * @NAME: vector_swap
+ * @DESC: Intercambia contenidos con otro vector
+ */
+void vector_swap(vector* v, vector* other);
+
+/**
+ * @NAME: vector_clear
+ * @DESC: Limpia los elementos
+ */
+void vector_clear(vector* v);
+
+// Non-C++ interface
+/**
+ * @NAME: vector_iterate
+ * @DESC: Itera los elementos con una función
+ */
+void vector_iterate(vector const* v, VectorClosureFn closureFn);
+
+#endif //vector_h__

--- a/tests/unit-tests/test_vector.c
+++ b/tests/unit-tests/test_vector.c
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2019 Sistemas Operativos - UTN FRBA. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <commons/collections/vector.h>
+#include <commons/string.h>
+#include <cspecs/cspec.h>
+
+typedef struct
+{
+    char* name;
+    unsigned char age;
+} t_person;
+
+static t_person person_create(char const* name, unsigned char age)
+{
+    return (t_person)
+    {
+        .name = string_duplicate((char*) name),
+        .age = age
+    };
+}
+
+static void person_destroy(t_person* self)
+{
+    free(self->name);
+}
+
+context (test_vector)
+{
+    void assert_person(t_person const* person, char const* name, unsigned char age)
+    {
+        should_ptr((void*) person) not be null;
+        should_string(person->name) be equal to((char*) name);
+        should_int(person->age) be equal to(age);
+    }
+
+    inline void assert_person_at_position(vector const* vector, size_t pos, char const* name, unsigned char age)
+    {
+        assert_person(vector_at(vector, pos), name, age);
+    }
+
+    describe ("Vector")
+    {
+        vector vec;
+        t_person temp;
+
+        before
+        {
+            vector_construct(&vec, sizeof(t_person), (VectorFreeFn) person_destroy, 0);
+        } end
+
+        after
+        {
+            vector_destruct(&vec);
+        } end
+
+        describe("Insertions")
+        {
+            it ("should insert a value at back")
+            {
+                temp = person_create("Matias", 24);
+                vector_push_back(&vec, &temp);
+                assert_person(vector_back(&vec), "Matias", 24);
+
+                temp = person_create("Gaston", 25);
+                vector_push_back(&vec, &temp);
+                assert_person(vector_back(&vec), "Gaston", 25);
+
+                should_int(vector_size(&vec)) be equal to(2);
+            } end
+
+            it ("should insert a value at position")
+            {
+                temp = person_create("Matias", 24);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Sebastian", 21);
+                vector_insert(&vec, 0, &temp);
+                assert_person_at_position(&vec, 0, "Sebastian", 21);
+                assert_person_at_position(&vec, 1, "Matias", 24);
+                should_int(vector_size(&vec)) be equal to(2);
+
+                temp = person_create("Gaston", 25);
+                vector_insert(&vec, 0, &temp);
+                assert_person_at_position(&vec, 0, "Gaston", 25);
+                assert_person_at_position(&vec, 1, "Sebastian", 21);
+                assert_person_at_position(&vec, 2, "Matias", 24);
+            } end
+
+            it("should add all elements from array at end")
+            {
+                t_person others[2];
+
+                temp = person_create("Matias", 24);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Gaston", 25);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Sebastian", 21);
+                vector_push_back(&vec, &temp);
+
+                others[0] = person_create("Daniela", 19);
+                others[1] = person_create("Facundo", 25);
+
+                should_int(vector_size(&vec)) be equal to(3);
+                vector_insert_range(&vec, vector_size(&vec), others, others + 2);
+                should_int(vector_size(&vec)) be equal to(5);
+
+                assert_person_at_position(&vec, 0, "Matias"   , 24);
+                assert_person_at_position(&vec, 1, "Gaston"   , 25);
+                assert_person_at_position(&vec, 2, "Sebastian", 21);
+                assert_person_at_position(&vec, 3, "Daniela"  , 19);
+                assert_person_at_position(&vec, 4, "Facundo"  , 25);
+            } end
+        } end
+
+        describe ("Replace, remove and destroy")
+        {
+            before
+            {
+                temp = person_create("Matias"   , 24);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Gaston"   , 25);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Sebastian", 21);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Ezequiel" , 25);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Facundo"  , 25);
+                vector_push_back(&vec, &temp);
+            } end
+
+            it("should replace a value at index with other value")
+            {
+                t_person daniela = person_create("Daniela", 19);
+                {
+                    t_person* old = vector_at(&vec, 3);
+                    assert_person(old, "Ezequiel", 25);
+                    vector_erase(&vec, 3);
+                }
+                vector_insert(&vec, 3, &daniela);
+
+                assert_person_at_position(&vec, 0, "Matias"   , 24);
+                assert_person_at_position(&vec, 1, "Gaston"   , 25);
+                assert_person_at_position(&vec, 2, "Sebastian", 21);
+                assert_person_at_position(&vec, 3, "Daniela"  , 19);
+                assert_person_at_position(&vec, 4, "Facundo"  , 25);
+            } end
+
+            it("should remove and destroy a value at index")
+            {
+                should_int(vector_size(&vec)) be equal to(5);
+
+                {
+                    t_person* aux = vector_front(&vec);
+                    assert_person(aux, "Matias", 24);
+                    vector_erase(&vec, 0);
+                }
+
+                assert_person_at_position(&vec, 0, "Gaston", 25);
+                should_int(vector_size(&vec)) be equal to(4);
+            } end
+
+            it ("should remove and destroy a range of indices")
+            {
+                should_int(vector_size(&vec)) be equal to (5);
+
+                vector_erase_range(&vec, 1, 3);
+
+                should_int(vector_size(&vec)) be equal to (3);
+                assert_person_at_position(&vec, 0, "Matias"  , 24);
+                assert_person_at_position(&vec, 1, "Ezequiel", 25);
+                assert_person_at_position(&vec, 2, "Facundo" , 25);
+            } end
+
+            it ("should remove last element")
+            {
+                should_int(vector_size(&vec)) be equal to(5);
+                t_person* aux = vector_back(&vec);
+                assert_person(aux, "Facundo", 25);
+
+                vector_pop_back(&vec);
+                aux = vector_back(&vec);
+
+                assert_person(aux, "Ezequiel", 25);
+                should_int(vector_size(&vec)) be equal to (4);
+            } end
+
+            it("should remove the first value that satisfies a condition")
+            {
+                should_int(vector_size(&vec)) be equal to(5);
+
+                t_person const* ps = vector_data(&vec);
+                for (size_t i = 0; i < vector_size(&vec); ++i)
+                {
+                    if (string_equals_ignore_case(ps[i].name, "Gaston"))
+                    {
+                        vector_erase(&vec, i);
+                        break;
+                    }
+                }
+
+                should_int(vector_size(&vec)) be equal to(4);
+            } end
+
+            it("should clean a vector and leave it empty")
+            {
+                should_int(vector_size(&vec)) be equal to(5);
+                vector_clear(&vec);
+                should_bool(vector_empty(&vec)) be truthy;
+            } end
+        } end
+
+        describe ("Higher order functions")
+        {
+            before
+            {
+                temp = person_create("Matias"   , 24);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Gaston"   , 25);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Sebastian", 21);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Ezequiel" , 25);
+                vector_push_back(&vec, &temp);
+
+                temp = person_create("Facundo"  , 25);
+                vector_push_back(&vec, &temp);
+            } end
+
+            it("should filter a vector with the values that satisfies a condition")
+            {
+                should_int(vector_size(&vec)) be equal to(5);
+
+                vector young_people;
+                vector_construct(&young_people, sizeof(t_person), NULL, 0);
+                void _addYoungPeople(t_person const* person)
+                {
+                    if (person->age <= 24)
+                        vector_push_back(&young_people, person);
+                }
+                vector_iterate(&vec, (VectorClosureFn) _addYoungPeople);
+
+                should_int(vector_size(&young_people)) be equal to(2);
+                assert_person_at_position(&young_people, 0, "Matias", 24);
+                assert_person_at_position(&young_people, 1, "Sebastian", 21);
+                vector_destruct(&young_people);
+            } end
+
+            it("should map a vector with the function result")
+            {
+                char const* names_array[] = { "Matias", "Gaston", "Sebastian", "Ezequiel", "Facundo" };
+
+                vector names;
+                vector_construct(&names, sizeof(char*), NULL, 0);
+                void _getNames(t_person const* person)
+                {
+                    vector_push_back(&names, &person->name);
+                }
+
+                vector_iterate(&vec, (VectorClosureFn) _getNames);
+                for (size_t i = 0; i < 5; ++i)
+                    should_string(*(char**) vector_at(&names, i)) be equal to((char*) names_array[i]);
+
+                vector_destruct(&names);
+            } end
+
+        } end
+
+        describe ("Swap")
+        {
+            before
+            {
+               temp = person_create("Matias"   , 24);
+               vector_push_back(&vec, &temp);
+
+               temp = person_create("Gaston"   , 25);
+               vector_push_back(&vec, &temp);
+
+               temp = person_create("Sebastian", 21);
+               vector_push_back(&vec, &temp);
+
+               temp = person_create("Ezequiel" , 25);
+               vector_push_back(&vec, &temp);
+
+               temp = person_create("Facundo"  , 25);
+               vector_push_back(&vec, &temp);
+            } end
+
+            it("should exchange contents with another vector")
+            {
+                vector other;
+                vector_construct(&other, sizeof(t_person), (VectorFreeFn) person_destroy, 0);
+
+                temp = person_create("Lucas", 31);
+                vector_push_back(&other, &temp);
+
+                temp = person_create("Pablo", 19);
+                vector_push_back(&other, &temp);
+
+                should_int(vector_size(&other)) be equal to (2);
+
+                vector_swap(&vec, &other);
+
+                should_int(vector_size(&other)) be equal to (5);
+                assert_person_at_position(&other, 0, "Matias"   , 24);
+                assert_person_at_position(&other, 1, "Gaston"   , 25);
+                assert_person_at_position(&other, 2, "Sebastian", 21);
+                assert_person_at_position(&other, 3, "Ezequiel", 25);
+                assert_person_at_position(&other, 4, "Facundo", 25);
+
+                vector_destruct(&other);
+            } end
+        } end
+
+        describe ("Iterator")
+        {
+
+            it("should iterate all vector values")
+            {
+                temp = person_create("Matias"   , 24);
+                vector_push_back(&vec, &temp);
+                temp = person_create("Gaston"   , 25);
+                vector_push_back(&vec, &temp);
+                temp = person_create("Sebastian", 21);
+                vector_push_back(&vec, &temp);
+                temp = person_create("Daniela"  , 19);
+                vector_push_back(&vec, &temp);
+
+                char* const names_array[] = { "Matias", "Gaston", "Sebastian", "Daniela" };
+                int index = 0;
+
+                void _list_elements(void* p)
+                {
+                    t_person* person = p;
+
+                    should_ptr(person) not be null;
+                    should_string(person->name) be equal to(names_array[index++]);
+                }
+
+                vector_iterate(&vec, _list_elements);
+                should_int(index) be equal to(4);
+            } end
+
+        } end
+    } end
+}


### PR DESCRIPTION
Buenas! Utilicé este tipo cuando hacía el TP y creo que estaría bien para la commons library.

El vector utiliza memoria contigua del heap, en lugar de bloques enlazados como la lista; aprovechando mejor así el concepto de localidad espacial en el que se basan las memorias caché. Para amortizar la operación de inserción, que en lista es O(1), el vector se redimensiona al doble de su tamaño cuando se termina su capacidad, logrando un tiempo promedio de orden logarítmico.

La abstracción utilizada (ya que C carece de referencias) es de "puntero a tipo". Lo someti a la batería de tests que copié de lista y modifiqué un poco para testear las otras funciones.

La interfaz está basada en el tipo vector de c++, por lo que podremos encontrar cosas como `push_back` y `front`. Además y para mantenerme fiel a la interfaz original, el destructor de elemento se pasa como parámetro del constructor; en lugar de tener que pasarlo para todas las funciones que borren elementos.

- [x] los elementos se guardan contiguos, no hay necesidad de administrar una reserva aparte para los mismos (como en lista)
- [x] incluye un _shortcut_ para crear vectores de strings, con memoria administrada por el vector!, (en un futuro se podria utilizar para reescribir ie. string_split para que devuelva un vector con las cadenas token)

Ejemplo de uso:
```c
// vector of char*'s
vector v = VECTOR_OF_STRINGS_INITIALIZER;
char* string = strdup("Hola");

// need to pass "reference" to char*, so we use addressof operator
vector_push_back(&v, &string);

string = strdup("Chau");
vector_push_back(&v, &string);

// vector uses "pointer to type" (char*)
void _print_strings(char** elem)
{
    printf("%s\n", *elem);
}

vector_iterate(&v, (VectorClosureFn) _print_strings);

// also frees memory used by strings!
vector_destruct(&v);
```
