### PR TITLE
Fix string_split bug

### DIFF
--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -53,7 +53,11 @@ t_config *config_create(char *path) {
 	void add_cofiguration(char *line) {
 		if (!string_starts_with(line, "#")) {
 			char** keyAndValue = string_n_split(line, 2, "=");
-			dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
+			if(strcmp(keyAndValue[0],"")) {
+				dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
+			} else {
+				free(keyAndValue[1]);
+			}
 			free(keyAndValue[0]);
 			free(keyAndValue);
 		}

--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -51,13 +51,10 @@ t_config *config_create(char *path) {
 	char** lines = string_split(buffer, "\n");
 
 	void add_cofiguration(char *line) {
-		if (!string_starts_with(line, "#")) {
+		if (strcmp(line,"") && !string_starts_with(line, "#")) {
 			char** keyAndValue = string_n_split(line, 2, "=");
-			if(strcmp(keyAndValue[0],"")) {
-				dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
-			} else {
-				free(keyAndValue[1]);
-			}
+			dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
+
 			free(keyAndValue[0]);
 			free(keyAndValue);
 		}

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -145,14 +145,14 @@ bool string_equals_ignore_case(char *actual, char *expected) {
 
 char **string_split(char *text, char *separator) {
 	bool _is_last_token(char* next, int _) {
-		return next[0] != '\0';
+		return next != NULL;
 	}
 	return _string_split(text, separator, _is_last_token);
 }
 
 char** string_n_split(char *text, int n, char* separator) {
 	bool _is_last_token(char* next, int index) {
-		return next[0] != '\0' && index < (n - 1);
+		return next != NULL && index < (n - 1);
 	}
 	return _string_split(text, separator, _is_last_token);
 }
@@ -252,22 +252,19 @@ char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) 
 	int size = 0;
 
 	char *text_to_iterate = string_duplicate(text);
-
 	char *next = text_to_iterate;
-	char *str = text_to_iterate;
 
 	while(condition(next, size)) {
-		char* token = strtok_r(str, separator, &next);
+		char* token = strsep(&next, separator);
 		if(token == NULL) {
 			break;
 		}
-		str = NULL;
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(token);
 	};
 
-	if (next[0] != '\0') {
+	if (next != NULL) {
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(next);

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -89,8 +89,9 @@ context (test_config) {
                     should_string(config_get_string_value(config, "EMPTY_ARRAY")) be equal to("[]");
                     char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
 
-                    char* empty_array_expected[] = {NULL};
-                    _assert_equals_array(empty_array_expected, empty_array, 0);
+                    should_ptr(empty_array) not be null;
+                    should_string(empty_array[0]) be equal to ("");
+                    free(empty_array[0]);
                     free(empty_array);
                 } end
 

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -192,9 +192,7 @@ context (test_string) {
                     should_string(substrings[2]) be equal to("tierra");
                     should_ptr(substrings[3]) be null;
 
-                    free(substrings[0]);
-                    free(substrings[1]);
-                    free(substrings[2]);
+				    string_iterate_lines(substrings, (void*) free);
                     free(substrings);
                 } end
 
@@ -203,13 +201,56 @@ context (test_string) {
                     char** substrings = string_split(line, ";");
 
                     should_ptr(substrings) not be null;
-                    should_ptr(substrings[0]) be null;
+                    should_string(substrings[0]) be equal to("");
 
+				    string_iterate_lines(substrings, (void*) free);
                     free(substrings);
 
                 } end
 
-                it("n_split_when_n_is_less_than_splitted_elements") {
+				 it("split_when_starts_with_delimitator") {
+                	char* line = ",Hola,planeta,tierra";
+				    char** substrings = string_split(line, ",");
+
+				    should_ptr(substrings) not be null;
+				    should_string(substrings[0]) be equal to ("");
+				    should_string(substrings[1]) be equal to ("Hola");
+				    should_string(substrings[2]) be equal to ("planeta");
+				    should_string(substrings[3]) be equal to ("tierra");
+
+				    string_iterate_lines(substrings, (void*) free);
+				    free(substrings);
+                } end
+
+				it("split_when_ends_with_delimitator") {
+				  	char* line = "Hola,planeta,tierra,";
+				   	char** substrings = string_split(line, ",");
+
+				   	should_ptr(substrings) not be null;
+                	should_string(substrings[0]) be equal to ("Hola");
+                	should_string(substrings[1]) be equal to ("planeta");
+                	should_string(substrings[2]) be equal to ("tierra");
+                	should_string(substrings[3]) be equal to ("");
+
+                	string_iterate_lines(substrings, (void*) free);
+					free(substrings);
+                } end
+
+				it("split_when_has_delimitators_in_between") {
+                	char* line = "Hola,planeta,,tierra";
+                	char** substrings = string_split(line, ",");
+
+                	should_ptr(substrings) not be null;
+                	should_string(substrings[0]) be equal to ("Hola");
+                	should_string(substrings[1]) be equal to ("planeta");
+                	should_string(substrings[2]) be equal to ("");
+                	should_string(substrings[3]) be equal to ("tierra");
+
+                	string_iterate_lines(substrings, (void*) free);
+					free(substrings);
+                } end
+
+				it("n_split_when_n_is_less_than_splitted_elements") {
                     char *line = "Hola planeta tierra";
                     char** substrings = string_n_split(line, 2, " ");
 
@@ -267,8 +308,9 @@ context (test_string) {
                     char** substrings = string_n_split(line, 10, ";");
 
                     should_ptr(substrings) not be null;
-                    should_ptr(substrings[0]) be null;
+                    should_string(substrings[0]) be equal to("");
 
+				    string_iterate_lines(substrings, (void*) free);
                     free(substrings);
                 } end
 
@@ -380,7 +422,9 @@ context (test_string) {
                     char* string_empty_array = "[]";
                     char** empty_array = string_get_string_as_array(string_empty_array);
                     should_ptr(empty_array) not be null;
-                    should_ptr(empty_array[0]) be null;
+                    should_string(empty_array[0]) be equal to("");
+
+				    string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);
                 } end
 


### PR DESCRIPTION
Buenas! Diseñé una nueva versión de `string_split` que resuelve el bug mencionado en el issue https://github.com/sisoputnfrba/so-commons-library/issues/57 

Ahora usa `strsep` en lugar de `strtok_r`, lo que le permite comportarse igual que en JS:
```
//Antes:
string_split("//Hola//planeta/tierra/","/"); => ["Hola","planeta","tierra", NULL]
//Ahora:
string_split("//Hola//planeta/tierra/","/"); => ["","","Hola","","planeta","tierra","", NULL]
```
Esto cambió el comportamiento de la función cuando recibe un string vacío (`""`):
```
//Antes:
string_split("","/"); => [NULL]
//Ahora:
string_split("","/"); => ["", NULL]
```
Por lo que tuve que cambiar algunos tests para que coincidiera con el nuevo comportamiento. También agregué otros nuevos para verificar que `string_split` funcione como en JS.

Un problema que surgió fue con la función `config_create`: al leer un config con `\n\n` devolvía una línea `""` en medio de ellos =>  `dictionary_put` creaba una nueva key de nombre `""` y de valor `NULL` => la cantidad de keys que retornaba `config_keys_amount` era una más de la que debía ser. 

Lo resolví agregando una condición para que no considere las líneas vacías, al igual que tampoco considera las comentadas con `#`.

Saludos!