### PR TITLE
Nuevas features para string

### DIFF
--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -51,7 +51,7 @@ t_config *config_create(char *path) {
 	char** lines = string_split(buffer, "\n");
 
 	void add_cofiguration(char *line) {
-		if (!string_starts_with(line, "#")) {
+		if (!string_is_empty(line) && !string_starts_with(line, "#")) {
 			char** keyAndValue = string_n_split(line, 2, "=");
 			dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
 			free(keyAndValue[0]);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -234,36 +234,23 @@ int string_array_size(char** array) {
 }
 
 char* string_replace(char* text, char* pattern, char* replacement) {
-	if(text[0] == '\0' && pattern[0] == '\0') {
-		return string_duplicate(replacement);
+	if(pattern[0] == '\0') {
+		return strdup(text);
 	}
+	char* result = strdup("");
 
-	char* result = string_new();
-	char* non_replaced_part;
+	char* start = text;
+	char* next;
 
-	int i = 0, start = 0;
-	while(text[i] != '\0') {
-		if(string_starts_with(text + i, pattern)) {
-			if(pattern[0] == '\0') {
-				string_append(&result, replacement);
-				i++;
-			} else {
-				non_replaced_part = string_substring(text, start, i - start);
-				string_append(&result, non_replaced_part);
-				string_append(&result, replacement);
-				free(non_replaced_part);
-				i += strlen(pattern);
-			}
-			start = i;
-		} else {
-			i++;
-		}
+	while((next = strstr(start, pattern)) != NULL) {
+		result = realloc(result, strlen(result) + (size_t)(next - start) + strlen(replacement) + 1);
+		strncat(result, start, (size_t)(next - start));
+		strcat(result, replacement);
+
+		start = next + strlen(pattern);
 	}
-	if(start < i) {
-		non_replaced_part = string_substring(text, start, i - start);
-		string_append(&result, non_replaced_part);
-		free(non_replaced_part);
-	}
+	result = realloc(result, strlen(result) + strlen(start) + 1);
+	strncat(result, start, (size_t)(next - start));
 
 	return result;
 }

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -49,6 +49,14 @@ void string_append(char** original, char* string_to_add) {
 	strcat(*original, string_to_add);
 }
 
+void string_n_append(char** original, char* string_to_add, int n) {
+	if(strlen(string_to_add) < n) {
+		n = strlen(string_to_add);
+	}
+	*original = realloc(*original, strlen(*original) + n + 1);
+	strncat(*original, string_to_add, n);
+}
+
 char* string_new() {
 	return string_duplicate("");
 }
@@ -69,7 +77,7 @@ char* string_from_vformat(const char* format, va_list arguments) {
 }
 
 char* string_itoa(int number) {
-    return string_from_format("%d", number);
+	return string_from_format("%d", number);
 }
 
 void string_append_with_format(char **original, const char *format, ...) {
@@ -163,22 +171,22 @@ char** string_n_split(char *text, int n, char* separator) {
 	return _string_split(text, separator, _is_last_token);
 }
 
-char**  string_get_string_as_array(char* text) {
-    int length_value = strlen(text) - 2;
-    char* value_without_brackets = string_substring(text, 1, length_value);
-    char **array_values = string_split(value_without_brackets, ",");
+char** string_get_string_as_array(char* text) {
+	int length_value = strlen(text) - 2;
+	char* value_without_brackets = string_substring(text, 1, length_value);
+	char **array_values = string_split(value_without_brackets, ",");
 
-    int i = 0;
-    while (array_values[i] != NULL) {
-	    string_trim(&(array_values[i]));
-	    i++;
-    }
+	int i = 0;
+	while (array_values[i] != NULL) {
+		string_trim(&(array_values[i]));
+		i++;
+	}
 
-    free(value_without_brackets);
-    return array_values;
+	free(value_without_brackets);
+	return array_values;
 }
 
-char*   string_substring(char* text, int start, int length) {
+char* string_substring(char* text, int start, int length) {
 	char* new_string = calloc(1, length + 1);
 	strncpy(new_string, text + start, length);
 	return new_string;
@@ -204,21 +212,21 @@ int string_length(char* text) {
 }
 
 char* string_reverse(char* text) {
-    char* result = calloc(1, string_length(text) + 1);
+	char* result = calloc(1, string_length(text) + 1);
 
-    int i = string_length(text) - 1, j = 0;
-    while (i >= 0){
-        result[j] = text[i];
-        i--;
-        j++;
-    }
+	int i = string_length(text) - 1, j = 0;
+	while (i >= 0){
+		result[j] = text[i];
+		i--;
+		j++;
+	}
 
-    return result;
+	return result;
 }
 
 char** string_array_new() {
 	char** array = malloc(sizeof(char*));
-	array[0] = NULL;
+	*array = NULL;
 
 	return array;
 }
@@ -234,29 +242,27 @@ int string_array_size(char** array) {
 }
 
 char* string_replace(char* text, char* pattern, char* replacement) {
-	if(pattern[0] == '\0') {
-		return strdup(text);
+	if(*pattern == '\0') {
+		return string_duplicate(text);
 	}
-	char* result = strdup("");
 
+	char* result = string_new();
 	char* start = text;
 	char* next;
 
 	while((next = strstr(start, pattern)) != NULL) {
-		result = realloc(result, strlen(result) + (size_t)(next - start) + strlen(replacement) + 1);
-		strncat(result, start, (size_t)(next - start));
-		strcat(result, replacement);
+		string_n_append(&result, start, next - start);
+		string_append(&result, replacement);
 
 		start = next + strlen(pattern);
 	}
-	result = realloc(result, strlen(result) + strlen(start) + 1);
-	strncat(result, start, (size_t)(next - start));
+	string_append(&result, start);
 
 	return result;
 }
 
 bool string_array_is_empty(char** array) {
-	return array[0] == NULL;
+	return *array == NULL;
 }
 
 void string_array_push(char*** array, char* text) {

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -27,6 +27,8 @@ static void _string_lower_element(char* ch);
 static void _string_upper_element(char* ch);
 void _string_append_with_format_list(const char* format, char** original, va_list arguments);
 char** _string_split(char* text, char* separator, bool(*condition)(char*, int));
+static void _string_array_push(char*** array, char* text, int size);
+static char* _string_array_replace(char** array, int pos, char* text);
 
 
 char *string_repeat(char character, int count) {
@@ -139,6 +141,10 @@ bool string_ends_with(char* text, char* end) {
 	return strcmp(&text[index], end) == 0;
 }
 
+bool string_contains(char* text, char *substring) {
+	return strstr(text, substring) != NULL;
+}
+
 bool string_equals_ignore_case(char *actual, char *expected) {
 	return strcasecmp(actual, expected) == 0;
 }
@@ -197,21 +203,50 @@ int string_length(char* text) {
 	return strlen(text);
 }
 
-char* string_reverse(char* palabra) {
-    char* resultado = calloc(1, string_length(palabra) + 1);
+char* string_reverse(char* text) {
+    char* result = calloc(1, string_length(text) + 1);
 
-    int i = string_length(palabra) - 1, j = 0;
+    int i = string_length(text) - 1, j = 0;
     while (i >= 0){
-        resultado[j] = palabra[i];
+        result[j] = text[i];
         i--;
         j++;
     }
 
-    return resultado;
+    return result;
 }
 
-bool	string_contains(char* text, char *substring) {
-	return strstr(text, substring) != NULL;
+char** string_array_new() {
+	char** array = malloc(sizeof(char*));
+	array[0] = NULL;
+
+	return array;
+}
+
+int string_array_size(char** array) {
+	int size = 0;
+	void _count_lines(char* _) {
+		size++;
+	}
+	string_iterate_lines(array, _count_lines);
+
+	return size;
+}
+
+bool string_array_is_empty(char** array) {
+	return array[0] == NULL;
+}
+
+void string_array_push(char*** array, char* text) {
+	_string_array_push(array, text, string_array_size(*array));
+}
+
+char* string_array_replace(char** array, int pos, char* text) {
+	return string_array_size(array) > pos && pos >= 0 ? _string_array_replace(array, pos, text) : NULL;
+}
+
+char* string_array_pop(char** array) {
+	return string_array_size(array) > 0 ? _string_array_replace(array, string_array_size(array) - 1, NULL) : NULL;
 }
 
 /** PRIVATE FUNCTIONS **/
@@ -248,7 +283,7 @@ void _string_append_with_format_list(const char* format, char** original, va_lis
 }
 
 char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) {
-	char **substrings = NULL;
+	char **substrings = string_array_new();
 	int size = 0;
 
 	char *text_to_iterate = string_duplicate(text);
@@ -259,21 +294,28 @@ char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) 
 		if(token == NULL) {
 			break;
 		}
+		_string_array_push(&substrings, string_duplicate(token), size);
 		size++;
-		substrings = realloc(substrings, sizeof(char*) * size);
-		substrings[size - 1] = string_duplicate(token);
 	};
 
 	if (next != NULL) {
+		_string_array_push(&substrings, string_duplicate(next), size);
 		size++;
-		substrings = realloc(substrings, sizeof(char*) * size);
-		substrings[size - 1] = string_duplicate(next);
 	}
-
-	size++;
-	substrings = realloc(substrings, sizeof(char*) * size);
-	substrings[size - 1] = NULL;
 
 	free(text_to_iterate);
 	return substrings;
+}
+
+static void _string_array_push(char*** array, char* text, int size) {
+	*array = realloc(*array, sizeof(char*) * (size + 2));
+	(*array)[size] = text;
+	(*array)[size + 1] = NULL;
+}
+
+static char* _string_array_replace(char** array, int pos, char* text) {
+	char* old_text = array[pos];
+	array[pos] = text;
+
+	return old_text;
 }

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -145,14 +145,14 @@ bool string_equals_ignore_case(char *actual, char *expected) {
 
 char **string_split(char *text, char *separator) {
 	bool _is_last_token(char* next, int _) {
-		return next[0] != '\0';
+		return next != NULL;
 	}
 	return _string_split(text, separator, _is_last_token);
 }
 
 char** string_n_split(char *text, int n, char* separator) {
 	bool _is_last_token(char* next, int index) {
-		return next[0] != '\0' && index < (n - 1);
+		return next != NULL && index < (n - 1);
 	}
 	return _string_split(text, separator, _is_last_token);
 }
@@ -252,22 +252,19 @@ char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) 
 	int size = 0;
 
 	char *text_to_iterate = string_duplicate(text);
-
 	char *next = text_to_iterate;
-	char *str = text_to_iterate;
 
 	while(condition(next, size)) {
-		char* token = strtok_r(str, separator, &next);
+		char* token = strsep(&next, separator);
 		if(token == NULL) {
 			break;
 		}
-		str = NULL;
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(token);
 	};
 
-	if (next[0] != '\0') {
+	if (next != NULL) {
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(next);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -233,6 +233,41 @@ int string_array_size(char** array) {
 	return size;
 }
 
+char* string_replace(char* text, char* pattern, char* replacement) {
+	if(text[0] == '\0' && pattern[0] == '\0') {
+		return string_duplicate(replacement);
+	}
+
+	char* result = string_new();
+	char* non_replaced_part;
+
+	int i = 0, start = 0;
+	while(text[i] != '\0') {
+		if(string_starts_with(text + i, pattern)) {
+			if(pattern[0] == '\0') {
+				string_append(&result, replacement);
+				i++;
+			} else {
+				non_replaced_part = string_substring(text, start, i - start);
+				string_append(&result, non_replaced_part);
+				string_append(&result, replacement);
+				free(non_replaced_part);
+				i += strlen(pattern);
+			}
+			start = i;
+		} else {
+			i++;
+		}
+	}
+	if(start < i) {
+		non_replaced_part = string_substring(text, start, i - start);
+		string_append(&result, non_replaced_part);
+		free(non_replaced_part);
+	}
+
+	return result;
+}
+
 bool string_array_is_empty(char** array) {
 	return array[0] == NULL;
 }

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -81,7 +81,8 @@
 	* @NAME: string_replace
 	* @DESC: Retorna una copia de un string con todas las ocurrencias
 	* de 'pattern' siendo reemplazadas por 'replacement'. En caso de recibir
-	* el string vacío como patrón, reemplaza caracter a caracter.
+	* el string vacío como patrón, retorna una copia exacta del string 
+	* original.
 	*
 	* Ejemplo:
 	* char* original = "hello";

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -78,6 +78,19 @@
 	char*	string_reverse(char* text);
 
 	/**
+	* @NAME: string_replace
+	* @DESC: Retorna una copia de un string con todas las ocurrencias
+	* de 'pattern' siendo reemplazadas por 'replacement'. En caso de recibir
+	* el string vacío como patrón, reemplaza caracter a caracter.
+	*
+	* Ejemplo:
+	* char* original = "hello";
+	* string_replace(original, "o", "o world!") => "hello world!"
+	* string_replace(original, "", "a") => "aaaaa"
+	*/
+	char*	string_replace(char* text, char* pattern, char* replacement);
+
+	/**
 	* @NAME: string_append
 	* @DESC: Agrega al primer string el segundo
 	*

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -271,7 +271,7 @@
 	*
 	* Ejemplo:
 	* char* array_string = "[1,2,3,4]"
-	* string_get_string_as_array(array_string) => {"1","2","3","4", NULL}
+	* string_get_string_as_array(array_string) => ["1","2","3","4", NULL]
 	*/
 	char**  string_get_string_as_array(char* text);
 
@@ -309,7 +309,7 @@
 	char*   string_array_replace(char** array, int pos, char* text);
 
 	/**
-	* @NAME: string_array_push
+	* @NAME: string_array_pop
 	* @DESC: Quita el último string del array y lo retorna
 	*/
 	char*   string_array_pop(char** array);

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -27,16 +27,16 @@
 	char*   string_new();
 
 	/**
-	* @NAME: string_new
+	* @NAME: string_array_new
 	* @DESC: Crea un array de strings vacio
 	*/
-	char** string_array_new();
+	char**  string_array_new();
 
 	/**
 	* @NAME: string_itoa
 	* @DESC: Crea un string a partir de un numero
 	*/
-	char* string_itoa(int number);
+	char*   string_itoa(int number);
 
 	/**
 	* @NAME: string_from_format
@@ -75,7 +75,7 @@
 	 * char* original = "boo";
 	 * string_reverse(original) => "oob"
 	 */
-	char*	string_reverse(char* text);
+	char*   string_reverse(char* text);
 
 	/**
 	* @NAME: string_replace
@@ -87,9 +87,9 @@
 	* Ejemplo:
 	* char* original = "hello";
 	* string_replace(original, "o", "o world!") => "hello world!"
-	* string_replace(original, "", "a") => "aaaaa"
+	* string_replace(original, "", "a") => "hello"
 	*/
-	char*	string_replace(char* text, char* pattern, char* replacement);
+	char*   string_replace(char* text, char* pattern, char* replacement);
 
 	/**
 	* @NAME: string_append
@@ -102,7 +102,21 @@
 	*
 	* => unaPalabra = "HOLA PEPE"
 	*/
-	void 	string_append(char ** original, char * string_to_add);
+	void    string_append(char ** original, char * string_to_add);
+
+	/**
+	* @NAME: string_n_append
+	* @DESC: Agrega al primer string un máximo de n caracteres
+	* del segundo.
+	*
+	* Ejemplo:
+	* char *unaPalabra = string_new();
+	* string_n_append(&unaPalabra, "HOLA ", 10);
+	* string_n_append(&unaPalabra, "PEPE", 3);
+	*
+	* => unaPalabra = "HOLA PEP"
+	*/
+	void    string_n_append(char** original, char* string_to_add, int n);
 
 	/**
 	* @NAME: string_append_with_format
@@ -124,58 +138,58 @@
 	* @DESC: Retorna una copia del string pasado
 	* como argumento
 	*/
-	char*	string_duplicate(char* original);
+	char*   string_duplicate(char* original);
 
 	/**
 	* @NAME: string_to_upper
 	* @DESC: Pone en mayuscula todos los caracteres de un string
 	*/
-	void 	string_to_upper(char * text);
+	void    string_to_upper(char * text);
 
 	/**
 	* @NAME: string_to_lower
 	* @DESC: Pone en minuscula todos los caracteres de un string
 	*/
-	void 	string_to_lower(char * text);
+	void    string_to_lower(char * text);
 
 	/**
 	* @NAME: string_capitalized
 	* @DESC: Capitaliza un string
 	*/
-	void 	string_capitalized(char * text);
+	void    string_capitalized(char * text);
 
 	/**
 	* @NAME: string_trim
 	* @DESC: Remueve todos los caracteres
 	* vacios de la derecha y la izquierda
 	*/
-	void 	string_trim(char ** text);
+	void    string_trim(char ** text);
 
 	/**
 	* @NAME: string_trim_left
 	* @DESC: Remueve todos los caracteres
 	* vacios de la izquierda
 	*/
-	void 	string_trim_left(char ** text);
+	void    string_trim_left(char ** text);
 
 	/**
 	* @NAME: string_trim_right
 	* @DESC: Remueve todos los caracteres
 	* vacios de la derecha
 	*/
-	void 	string_trim_right(char ** text);
+	void    string_trim_right(char ** text);
 
 	/**
 	* @NAME: string_length
 	* @DESC: Retorna la longitud del string
 	*/
-	int 	string_length(char * text);
+	int     string_length(char * text);
 
 	/**
 	* @NAME: string_is_empty
 	* @DESC: Retorna si un string es ""
 	*/
-	bool 	string_is_empty(char * text);
+	bool    string_is_empty(char * text);
 
 	/**
 	* @NAME: string_starts_with
@@ -183,7 +197,7 @@
 	* si un string comienza con el
 	* string pasado por parametro
 	*/
-	bool 	string_starts_with(char * text, char * begin);
+	bool    string_starts_with(char * text, char * begin);
 
 	/**
 	* @NAME: string_ends_with
@@ -191,21 +205,21 @@
 	* si un string finaliza con el
 	* string pasado por parametro
 	*/
-	bool	string_ends_with(char* text, char* end);
+	bool    string_ends_with(char* text, char* end);
 
 	/**
 	 * @NAME: string_contains
 	 * @DESC: Retorna un boolean que indica si text contiene o no
 	 * a substring.
 	 */
-	bool	string_contains(char* text, char *substring);
+	bool    string_contains(char* text, char *substring);
 
 	/**
 	* @NAME: string_equals_ignore_case
 	* @DESC: Retorna si dos strings son iguales
 	* ignorando las mayusculas y minusculas
 	*/
-	bool 	string_equals_ignore_case(char * actual, char * expected);
+	bool    string_equals_ignore_case(char * actual, char * expected);
 
 	/**
 	* @NAME: string_substring
@@ -257,7 +271,7 @@
 	*
 	* Ejemplo:
 	* char* array_string = "[1,2,3,4]"
-	* string_get_value_as_array(array_string) => ["1","2","3","4"]
+	* string_get_string_as_array(array_string) => {"1","2","3","4", NULL}
 	*/
 	char**  string_get_string_as_array(char* text);
 
@@ -266,38 +280,38 @@
 	* @DESC: Itera un array de strings aplicando
 	* el closure a cada string, hasta que encuentre un NULL
 	*/
-	void 	string_iterate_lines(char ** strings, void (*closure)(char *));
+	void    string_iterate_lines(char ** strings, void (*closure)(char *));
 
 	/**
 	* @NAME: string_array_size
 	* @DESC: Retorna la cantidad de líneas del
 	* array de strings
 	*/
-	int 	string_array_size(char** array);
+	int     string_array_size(char** array);
 
 	/**
 	* @NAME: string_array_is_empty
 	* @DESC: Verifica si el array de strings está vacío
 	*/
-	bool 	string_array_is_empty(char** array);
+	bool    string_array_is_empty(char** array);
 
 	/**
 	* @NAME: string_array_push
 	* @DESC: Agrega un string al final del array
 	*/
-	void 	string_array_push(char*** array, char* text);
+	void    string_array_push(char*** array, char* text);
 
 	/**
 	* @NAME: string_array_replace
 	* @DESC: Reemplaza un string en un array por otro, retornando
 	* el anterior
 	*/
-	char*	string_array_replace(char** array, int pos, char* text);
+	char*   string_array_replace(char** array, int pos, char* text);
 
 	/**
 	* @NAME: string_array_push
 	* @DESC: Quita el último string del array y lo retorna
 	*/
-	char*	string_array_pop(char** array);
+	char*   string_array_pop(char** array);
 
 #endif /* STRING_UTILS_H_ */

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -27,6 +27,12 @@
 	char*   string_new();
 
 	/**
+	* @NAME: string_new
+	* @DESC: Crea un array de strings vacio
+	*/
+	char** string_array_new();
+
+	/**
 	* @NAME: string_itoa
 	* @DESC: Crea un string a partir de un numero
 	*/
@@ -59,6 +65,17 @@
 	*
 	*/
 	char*   string_repeat(char ch, int count);
+
+	/**
+	 * @NAME: string_reverse
+	 * @DESC: Retorna el texto invertido. No se maneja el caso de NULL,
+	 * si se pasa NULL su comportamiento no esta determinado.
+	 *
+	 * Ejemplo:
+	 * char* original = "boo";
+	 * string_reverse(original) => "oob"
+	 */
+	char*	string_reverse(char* text);
 
 	/**
 	* @NAME: string_append
@@ -163,35 +180,18 @@
 	bool	string_ends_with(char* text, char* end);
 
 	/**
+	 * @NAME: string_contains
+	 * @DESC: Retorna un boolean que indica si text contiene o no
+	 * a substring.
+	 */
+	bool	string_contains(char* text, char *substring);
+
+	/**
 	* @NAME: string_equals_ignore_case
 	* @DESC: Retorna si dos strings son iguales
 	* ignorando las mayusculas y minusculas
 	*/
 	bool 	string_equals_ignore_case(char * actual, char * expected);
-
-	/**
-	* @NAME: string_split
-	* @DESC: Separa un string dado un separador
-	*
-	* @Return: Retorna un array con cada palabra y en la última posición un NULL
-	*
-	* Ejemplo:
-	* string_split("hola, mundo", ",") => ["hola", " mundo", NULL]
-	*/
-	char**  string_split(char * text, char * separator);
-
-
-	/**
-	 * @NAME: string_n_split
-	 * @DESC: Separa un string tantas veces por su separador como n lo permita
-	 *
-	 * Ejemplo:
-	 * string_n_split("hola, mundo, bueno", 2, ",") => ["hola", " mundo, bueno", NULL]
-	 * string_n_split("hola, mundo, bueno", 3, ",") => ["hola", " mundo", " bueno", NULL]
-	 * string_n_split("hola, mundo, bueno", 10, ",") => ["hola", " mundo", " bueno", NULL]
-	 *
-	 */
-	char**  string_n_split(char* text, int n, char* separator);
 
 	/**
 	* @NAME: string_substring
@@ -214,11 +214,27 @@
 	char*   string_substring_until(char *text, int length);
 
 	/**
-	* @NAME: string_iterate_lines
-	* @DESC: Itera un array de strings aplicando
-	* el closure a cada string, hasta que encuentre un NULL
+	* @NAME: string_split
+	* @DESC: Separa un string dado un separador
+	*
+	* @Return: Retorna un array con cada palabra y en la última posición un NULL
+	*
+	* Ejemplo:
+	* string_split("hola, mundo", ",") => ["hola", " mundo", NULL]
 	*/
-	void 	string_iterate_lines(char ** strings, void (*closure)(char *));
+	char**  string_split(char * text, char * separator);
+
+	/**
+	 * @NAME: string_n_split
+	 * @DESC: Separa un string tantas veces por su separador como n lo permita
+	 *
+	 * Ejemplo:
+	 * string_n_split("hola, mundo, bueno", 2, ",") => ["hola", " mundo, bueno", NULL]
+	 * string_n_split("hola, mundo, bueno", 3, ",") => ["hola", " mundo", " bueno", NULL]
+	 * string_n_split("hola, mundo, bueno", 10, ",") => ["hola", " mundo", " bueno", NULL]
+	 *
+	 */
+	char**  string_n_split(char* text, int n, char* separator);
 
 	/**
 	* @NAME: string_get_string_as_array
@@ -232,21 +248,42 @@
 	char**  string_get_string_as_array(char* text);
 
 	/**
-	 * @NAME: string_reverse
-	 * @DESC: Retorna el texto invertido. No se maneja el caso de NULL,
-	 * si se pasa NULL su comportamiento no esta determinado.
-	 *
-	 * Ejemplo:
-	 * char* original = "boo";
-	 * string_reverse(original) => "oob"
-	 */
-	char*	string_reverse(char* text);
+	* @NAME: string_iterate_lines
+	* @DESC: Itera un array de strings aplicando
+	* el closure a cada string, hasta que encuentre un NULL
+	*/
+	void 	string_iterate_lines(char ** strings, void (*closure)(char *));
 
 	/**
-	 * @NAME: string_contains
-	 * @DESC: Retorna un boolean que indica si text contiene o no
-	 * a substring.
-	 */
-	bool	string_contains(char* text, char *substring);
+	* @NAME: string_array_size
+	* @DESC: Retorna la cantidad de líneas del
+	* array de strings
+	*/
+	int 	string_array_size(char** array);
+
+	/**
+	* @NAME: string_array_is_empty
+	* @DESC: Verifica si el array de strings está vacío
+	*/
+	bool 	string_array_is_empty(char** array);
+
+	/**
+	* @NAME: string_array_push
+	* @DESC: Agrega un string al final del array
+	*/
+	void 	string_array_push(char*** array, char* text);
+
+	/**
+	* @NAME: string_array_replace
+	* @DESC: Reemplaza un string en un array por otro, retornando
+	* el anterior
+	*/
+	char*	string_array_replace(char** array, int pos, char* text);
+
+	/**
+	* @NAME: string_array_push
+	* @DESC: Quita el último string del array y lo retorna
+	*/
+	char*	string_array_pop(char** array);
 
 #endif /* STRING_UTILS_H_ */

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -89,8 +89,10 @@ context (test_config) {
                     should_string(config_get_string_value(config, "EMPTY_ARRAY")) be equal to("[]");
                     char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
 
-                    char* empty_array_expected[] = {NULL};
-                    _assert_equals_array(empty_array_expected, empty_array, 0);
+                    char* empty_array_expected[] = {"", NULL};
+                    _assert_equals_array(empty_array_expected, empty_array, 1);
+
+                    string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);
                 } end
 

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -477,12 +477,105 @@ context (test_string) {
         } end
 
         it("Contains") {
-          should_bool(string_contains("Pablito clavo un clavito", "Pablito")) be truthy;
-          should_bool(string_contains("Pablito clavo un clavito", "pablito")) be falsey;
-          should_bool(string_contains("Pablito clavo un clavito", "lito")) be truthy;
-          should_bool(string_contains("Pablito clavo un clavito", "")) be truthy;
-          should_bool(string_contains("", "Pablito clavo un clavito")) be falsey;
-          should_bool(string_contains("", "")) be truthy;
+        	should_bool(string_contains("Pablito clavo un clavito", "Pablito")) be truthy;
+        	should_bool(string_contains("Pablito clavo un clavito", "pablito")) be falsey;
+        	should_bool(string_contains("Pablito clavo un clavito", "lito")) be truthy;
+        	should_bool(string_contains("Pablito clavo un clavito", "")) be truthy;
+        	should_bool(string_contains("", "Pablito clavo un clavito")) be falsey;
+        	should_bool(string_contains("", "")) be truthy;
+        } end
+
+		describe ("String array") {
+        	char** names;
+
+        	before {
+        		names = string_array_new();
+
+        		string_array_push(&names, "Gaston");
+        		string_array_push(&names, "Matias");
+        		string_array_push(&names, "Sebastian");
+        		string_array_push(&names, "Daniela");
+        	} end
+
+			after {
+        		free(names);
+        	} end
+
+			it ("add an element at the end") {
+        		string_array_push(&names, "Agustin");
+
+        		should_int(string_array_size(names)) be equal to (5);
+        		should_ptr(names[5]) be null;
+
+        		char* expected[] = {"Gaston", "Matias", "Sebastian", "Daniela", "Agustin"};
+        		int i = 0;
+        		void _assert_names(char* name) {
+        			should_ptr(name) not be null;
+        			should_string(name) be equal to (expected[i]);
+        			i++;
+        		}
+        		string_iterate_lines(names, _assert_names);
+        	} end
+
+			it("remove the last element") {
+        		char* name = string_array_pop(names);
+
+        		should_string(name) be equal to ("Daniela");
+
+        		should_int(string_array_size(names)) be equal to (3);
+        		should_ptr(names[3]) be null;
+
+        		char* expected[] = {"Gaston", "Matias", "Sebastian"};
+        		int i = 0;
+        		void _assert_names(char* name) {
+        			should_ptr(name) not be null;
+        		    should_string(name) be equal to (expected[i]);
+        			i++;
+        		}
+        		string_iterate_lines(names, _assert_names);
+        	} end
+
+			it ("not to remove elements in an empty array") {
+        		for(int i = 0; i < 10; i++) {
+        			string_array_pop(names);
+        		}
+
+        		should_int(string_array_size(names)) be equal to (0);
+        		should_bool(string_array_is_empty(names)) be truthy;
+        	} end
+
+			it("replace an element") {
+        		char* name = string_array_replace(names, 2, "Damian");
+
+        		should_string(name) be equal to ("Sebastian");
+
+        		char* expected[] = {"Gaston", "Matias", "Damian", "Daniela"};
+        		int i = 0;
+        		void _assert_names(char* name) {
+        			should_ptr(name) not be null;
+        		    should_string(name) be equal to (expected[i]);
+        			i++;
+        		}
+        		string_iterate_lines(names, _assert_names);
+        	} end
+
+			it("not to replace an element outside the array") {
+        		char* name = string_array_replace(names, 4, "Damian");
+
+        		should_ptr(name) be null;
+        		should_int(string_array_size(names)) be equal to (4);
+        		should_ptr(names[4]) be null;
+
+        		char* expected[] = {"Gaston", "Matias", "Sebastian", "Daniela"};
+        		int i = 0;
+        		void _assert_names(char* name) {
+        			should_ptr(name) not be null;
+        		    should_string(name) be equal to (expected[i]);
+        		    i++;
+        		}
+        		string_iterate_lines(names, _assert_names);
+        	} end
+
         } end
 
     } end

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -610,19 +610,9 @@ context (test_string) {
 	        	should_string(replaced) be equal to ("hello");
 	        } end
 
-			it ("replace duplicates empty string when doesn't receive empty string as pattern") {
-	        	replaced = string_replace("", "not empty", "test failed!");
-	        	should_string(replaced) be equal to ("");
-	        } end
-
-			it ("replace every character when receives empty string as pattern") {
-	        	replaced = string_replace("laugh", "", "ha");
-	        	should_string(replaced) be equal to ("hahahahaha");
-	        } end
-
-			it ("replace empty string when receives empty string as pattern") {
-	        	replaced = string_replace("", "", "a wild text appears!");
-	        	should_string(replaced) be equal to ("a wild text appears!");
+			it ("replace duplicates original when receives empty string as pattern") {
+	        	replaced = string_replace("hello", "", "test failed!");
+	        	should_string(replaced) be equal to ("hello");
 	        } end
 
 	    } end

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -182,95 +182,137 @@ context (test_string) {
 
         describe("Split") {
 
-                it("split_with_delimitators") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_split(line, " ");
+        	it("split_with_delimitators") {
+        		char *line = "path/to/file";
+                char** substrings = string_split(line, "/");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta");
-                    should_string(substrings[2]) be equal to("tierra");
-                    should_ptr(substrings[3]) be null;
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path");
+                should_string(substrings[1]) be equal to ("to");
+                should_string(substrings[2]) be equal to ("file");
+                should_ptr(substrings[3]) be null;
 
-                    free(substrings[0]);
-                    free(substrings[1]);
-                    free(substrings[2]);
-                    free(substrings);
-                } end
+				string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-                it("split_is_empty") {
-                    char* line = "";
-                    char** substrings = string_split(line, ";");
+			it("split_starting_with_delimitator") {
+              	char* line = "/path/to/file";
+				char** substrings = string_split(line, "/");
 
-                    should_ptr(substrings) not be null;
-                    should_ptr(substrings[0]) be null;
+				should_ptr(substrings) not be null;
+				should_string(substrings[0]) be equal to ("");
+                should_string(substrings[1]) be equal to ("path");
+                should_string(substrings[2]) be equal to ("to");
+                should_string(substrings[3]) be equal to ("file");
 
-                    free(substrings);
+				string_iterate_lines(substrings, (void*) free);
+				free(substrings);
+			} end
 
-                } end
+			it("split_ending_with_delimitator") {
+				char* line = "path/to/file/";
+				char** substrings = string_split(line, "/");
 
-                it("n_split_when_n_is_less_than_splitted_elements") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_n_split(line, 2, " ");
+				should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path");
+                should_string(substrings[1]) be equal to ("to");
+                should_string(substrings[2]) be equal to ("file");
+			    should_string(substrings[3]) be equal to ("");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta tierra");
-                    should_ptr(substrings[2]) be null;
+			    string_iterate_lines(substrings, (void*) free);
+				free(substrings);
+			} end
 
-                    string_iterate_lines(substrings, (void*) free);
-                    free(substrings);
-                } end
+			it("split_having_delimitators_in_between") {
+				char* line = "path/to//file";
+			    char** substrings = string_split(line, "/");
 
-                it("n_split_when_n_is_equals_than_splitted_elements") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_n_split(line, 3, " ");
+			    should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path");
+                should_string(substrings[1]) be equal to ("to");
+			    should_string(substrings[2]) be equal to ("");
+                should_string(substrings[3]) be equal to ("file");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta");
-                    should_string(substrings[2]) be equal to("tierra");
-                    should_ptr(substrings[3]) be null;
+			    string_iterate_lines(substrings, (void*) free);
+				free(substrings);
+			} end
 
-                    string_iterate_lines(substrings, (void*) free);
-                    free(substrings);
-                } end
+            it("split_is_empty") {
+                char* line = "";
+                char** substrings = string_split(line, "/");
 
-                it("n_split_when_separator_isnt_included") {
-                    char *line = "Hola planeta tierra";
-                    char ** substrings = string_n_split(line, 5, ";");
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to(line);
-                    should_ptr(substrings[1]) be null;
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
 
-                    string_iterate_lines(substrings, (void *) free);
-                    free(substrings);
-                } end
+            } end
 
-                it("n_split_when_n_is_greather_than_splitted_elements") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_n_split(line, 10, " ");
+            it("n_split_when_n_is_less_than_splitted_elements") {
+                char *line = "Hola planeta tierra";
+                char** substrings = string_n_split(line, 2, " ");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta");
-                    should_string(substrings[2]) be equal to("tierra");
-                    should_ptr(substrings[3]) be null;
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("Hola");
+                should_string(substrings[1]) be equal to("planeta tierra");
+                should_ptr(substrings[2]) be null;
 
-                    string_iterate_lines(substrings, (void*) free);
-                    free(substrings);
-                } end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-                it("n_split_is_empty") {
-                    char* line = "";
-                    char** substrings = string_n_split(line, 10, ";");
+            it("n_split_when_n_is_equals_than_splitted_elements") {
+                char *line = "Hola planeta tierra";
+                char** substrings = string_n_split(line, 3, " ");
 
-                    should_ptr(substrings) not be null;
-                    should_ptr(substrings[0]) be null;
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("Hola");
+                should_string(substrings[1]) be equal to("planeta");
+                should_string(substrings[2]) be equal to("tierra");
+                should_ptr(substrings[3]) be null;
 
-                    free(substrings);
-                } end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
+
+            it("n_split_when_separator_isnt_included") {
+                char *line = "Hola planeta tierra";
+                char ** substrings = string_n_split(line, 5, ";");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to(line);
+                should_ptr(substrings[1]) be null;
+
+                string_iterate_lines(substrings, (void *) free);
+                free(substrings);
+            } end
+
+            it("n_split_when_n_is_greather_than_splitted_elements") {
+                char *line = "Hola planeta tierra";
+                char** substrings = string_n_split(line, 10, " ");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("Hola");
+                should_string(substrings[1]) be equal to("planeta");
+                should_string(substrings[2]) be equal to("tierra");
+                should_ptr(substrings[3]) be null;
+
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
+
+            it("n_split_is_empty") {
+                char* line = "";
+                char** substrings = string_n_split(line, 10, ";");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("");
+
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
         } end
 
@@ -380,7 +422,9 @@ context (test_string) {
                     char* string_empty_array = "[]";
                     char** empty_array = string_get_string_as_array(string_empty_array);
                     should_ptr(empty_array) not be null;
-                    should_ptr(empty_array[0]) be null;
+                    should_string(empty_array[0]) be equal to("");
+
+                    string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);
                 } end
 

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -578,6 +578,55 @@ context (test_string) {
 
         } end
 
+		describe("Replace") {
+	        char* replaced;
+
+	        after {
+	        	free(replaced);
+	        } end
+
+	        it ("replace multiple occurrences") {
+	        	replaced = string_replace("hexxo worxd!", "x", "l");
+	        	should_string(replaced) be equal to ("hello world!");
+	        } end
+
+			it ("replace an occurrence with a longer one") {
+	        	replaced = string_replace("hello", "o", "o world!");
+	        	should_string(replaced) be equal to ("hello world!");
+	        } end
+
+			it ("replace an occurrence with a shorter one") {
+	        	replaced = string_replace("hello", "ello", "ola");
+	        	should_string(replaced) be equal to ("hola");
+	        } end
+
+			it ("replace every occurrence with empty string") {
+	        	replaced = string_replace("hello", "l", "");
+	        	should_string(replaced) be equal to ("heo");
+	        } end
+
+			it ("replace duplicates original when doesn't receive a substring as pattern") {
+	        	replaced = string_replace("hello", "definitely not a substring", "test failed!");
+	        	should_string(replaced) be equal to ("hello");
+	        } end
+
+			it ("replace duplicates empty string when doesn't receive empty string as pattern") {
+	        	replaced = string_replace("", "not empty", "test failed!");
+	        	should_string(replaced) be equal to ("");
+	        } end
+
+			it ("replace every character when receives empty string as pattern") {
+	        	replaced = string_replace("laugh", "", "ha");
+	        	should_string(replaced) be equal to ("hahahahaha");
+	        } end
+
+			it ("replace empty string when receives empty string as pattern") {
+	        	replaced = string_replace("", "", "a wild text appears!");
+	        	should_string(replaced) be equal to ("a wild text appears!");
+	        } end
+
+	    } end
+
     } end
 
 }

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -50,6 +50,17 @@ context (test_string) {
             free(string);
         } end
 
+        it("n_append") {
+            char *string = string_new();
+            string_n_append(&string, "Hello", 10);
+            string_n_append(&string, "     ", 1);
+            string_n_append(&string, "world", 5);
+
+            should_string(string) be equal to("Hello world");
+
+            free(string);
+        } end
+
         it("append_with_format") {
             char *string = string_new();
 
@@ -181,9 +192,8 @@ context (test_string) {
         } end
 
         describe("Split") {
-
-        	it("split_with_delimitators") {
-        		char *line = "path/to/file";
+            it("split_with_delimitators") {
+                char *line = "path/to/file";
                 char** substrings = string_split(line, "/");
 
                 should_ptr(substrings) not be null;
@@ -192,51 +202,51 @@ context (test_string) {
                 should_string(substrings[2]) be equal to ("file");
                 should_ptr(substrings[3]) be null;
 
-				string_iterate_lines(substrings, (void*) free);
+                string_iterate_lines(substrings, (void*) free);
                 free(substrings);
             } end
 
-			it("split_starting_with_delimitator") {
-              	char* line = "/path/to/file";
-				char** substrings = string_split(line, "/");
+            it("split_starting_with_delimitator") {
+                char* line = "/path/to/file";
+                char** substrings = string_split(line, "/");
 
-				should_ptr(substrings) not be null;
-				should_string(substrings[0]) be equal to ("");
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("");
                 should_string(substrings[1]) be equal to ("path");
                 should_string(substrings[2]) be equal to ("to");
                 should_string(substrings[3]) be equal to ("file");
 
-				string_iterate_lines(substrings, (void*) free);
-				free(substrings);
-			} end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-			it("split_ending_with_delimitator") {
-				char* line = "path/to/file/";
-				char** substrings = string_split(line, "/");
+            it("split_ending_with_delimitator") {
+                char* line = "path/to/file/";
+                char** substrings = string_split(line, "/");
 
-				should_ptr(substrings) not be null;
+                should_ptr(substrings) not be null;
                 should_string(substrings[0]) be equal to ("path");
                 should_string(substrings[1]) be equal to ("to");
                 should_string(substrings[2]) be equal to ("file");
-			    should_string(substrings[3]) be equal to ("");
+                should_string(substrings[3]) be equal to ("");
 
-			    string_iterate_lines(substrings, (void*) free);
-				free(substrings);
-			} end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-			it("split_having_delimitators_in_between") {
-				char* line = "path/to//file";
-			    char** substrings = string_split(line, "/");
+            it("split_having_delimitators_in_between") {
+                char* line = "path/to//file";
+                char** substrings = string_split(line, "/");
 
-			    should_ptr(substrings) not be null;
+                should_ptr(substrings) not be null;
                 should_string(substrings[0]) be equal to ("path");
                 should_string(substrings[1]) be equal to ("to");
-			    should_string(substrings[2]) be equal to ("");
+                should_string(substrings[2]) be equal to ("");
                 should_string(substrings[3]) be equal to ("file");
 
-			    string_iterate_lines(substrings, (void*) free);
-				free(substrings);
-			} end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
             it("split_is_empty") {
                 char* line = "";
@@ -477,145 +487,145 @@ context (test_string) {
         } end
 
         it("Contains") {
-        	should_bool(string_contains("Pablito clavo un clavito", "Pablito")) be truthy;
-        	should_bool(string_contains("Pablito clavo un clavito", "pablito")) be falsey;
-        	should_bool(string_contains("Pablito clavo un clavito", "lito")) be truthy;
-        	should_bool(string_contains("Pablito clavo un clavito", "")) be truthy;
-        	should_bool(string_contains("", "Pablito clavo un clavito")) be falsey;
-        	should_bool(string_contains("", "")) be truthy;
+            should_bool(string_contains("Pablito clavo un clavito", "Pablito")) be truthy;
+            should_bool(string_contains("Pablito clavo un clavito", "pablito")) be falsey;
+            should_bool(string_contains("Pablito clavo un clavito", "lito")) be truthy;
+            should_bool(string_contains("Pablito clavo un clavito", "")) be truthy;
+            should_bool(string_contains("", "Pablito clavo un clavito")) be falsey;
+            should_bool(string_contains("", "")) be truthy;
         } end
 
-		describe ("String array") {
-        	char** names;
+        describe ("String array") {
+            char** names;
 
-        	before {
-        		names = string_array_new();
+            before {
+                names = string_array_new();
 
-        		string_array_push(&names, "Gaston");
-        		string_array_push(&names, "Matias");
-        		string_array_push(&names, "Sebastian");
-        		string_array_push(&names, "Daniela");
-        	} end
+                string_array_push(&names, "Gaston");
+                string_array_push(&names, "Matias");
+                string_array_push(&names, "Sebastian");
+                string_array_push(&names, "Daniela");
+            } end
 
-			after {
-        		free(names);
-        	} end
+            after {
+                free(names);
+            } end
 
-			it ("add an element at the end") {
-        		string_array_push(&names, "Agustin");
+            it ("add an element at the end") {
+                string_array_push(&names, "Agustin");
 
-        		should_int(string_array_size(names)) be equal to (5);
-        		should_ptr(names[5]) be null;
+                should_int(string_array_size(names)) be equal to (5);
+                should_ptr(names[5]) be null;
 
-        		char* expected[] = {"Gaston", "Matias", "Sebastian", "Daniela", "Agustin"};
-        		int i = 0;
-        		void _assert_names(char* name) {
-        			should_ptr(name) not be null;
-        			should_string(name) be equal to (expected[i]);
-        			i++;
-        		}
-        		string_iterate_lines(names, _assert_names);
-        	} end
+                char* expected[] = {"Gaston", "Matias", "Sebastian", "Daniela", "Agustin"};
+                int i = 0;
+                void _assert_names(char* name) {
+                    should_ptr(name) not be null;
+                    should_string(name) be equal to (expected[i]);
+                    i++;
+                }
+                string_iterate_lines(names, _assert_names);
+            } end
 
-			it("remove the last element") {
-        		char* name = string_array_pop(names);
+            it("remove the last element") {
+                char* name = string_array_pop(names);
 
-        		should_string(name) be equal to ("Daniela");
+                should_string(name) be equal to ("Daniela");
 
-        		should_int(string_array_size(names)) be equal to (3);
-        		should_ptr(names[3]) be null;
+                should_int(string_array_size(names)) be equal to (3);
+                should_ptr(names[3]) be null;
 
-        		char* expected[] = {"Gaston", "Matias", "Sebastian"};
-        		int i = 0;
-        		void _assert_names(char* name) {
-        			should_ptr(name) not be null;
-        		    should_string(name) be equal to (expected[i]);
-        			i++;
-        		}
-        		string_iterate_lines(names, _assert_names);
-        	} end
+                char* expected[] = {"Gaston", "Matias", "Sebastian"};
+                int i = 0;
+                void _assert_names(char* name) {
+                should_ptr(name) not be null;
+                    should_string(name) be equal to (expected[i]);
+                    i++;
+                }
+                string_iterate_lines(names, _assert_names);
+            } end
 
-			it ("not to remove elements in an empty array") {
-        		for(int i = 0; i < 10; i++) {
-        			string_array_pop(names);
-        		}
+            it ("not to remove elements in an empty array") {
+                for(int i = 0; i < 10; i++) {
+                    string_array_pop(names);
+                }
 
-        		should_int(string_array_size(names)) be equal to (0);
-        		should_bool(string_array_is_empty(names)) be truthy;
-        	} end
+                should_int(string_array_size(names)) be equal to (0);
+                should_bool(string_array_is_empty(names)) be truthy;
+            } end
 
-			it("replace an element") {
-        		char* name = string_array_replace(names, 2, "Damian");
+            it("replace an element") {
+                char* name = string_array_replace(names, 2, "Damian");
 
-        		should_string(name) be equal to ("Sebastian");
+                should_string(name) be equal to ("Sebastian");
 
-        		char* expected[] = {"Gaston", "Matias", "Damian", "Daniela"};
-        		int i = 0;
-        		void _assert_names(char* name) {
-        			should_ptr(name) not be null;
-        		    should_string(name) be equal to (expected[i]);
-        			i++;
-        		}
-        		string_iterate_lines(names, _assert_names);
-        	} end
+                char* expected[] = {"Gaston", "Matias", "Damian", "Daniela"};
+                int i = 0;
+                void _assert_names(char* name) {
+                    should_ptr(name) not be null;
+                    should_string(name) be equal to (expected[i]);
+                    i++;
+                }
+                string_iterate_lines(names, _assert_names);
+            } end
 
-			it("not to replace an element outside the array") {
-        		char* name = string_array_replace(names, 4, "Damian");
+            it("not to replace an element outside the array") {
+                char* name = string_array_replace(names, 4, "Damian");
 
-        		should_ptr(name) be null;
-        		should_int(string_array_size(names)) be equal to (4);
-        		should_ptr(names[4]) be null;
+                should_ptr(name) be null;
+                should_int(string_array_size(names)) be equal to (4);
+                should_ptr(names[4]) be null;
 
-        		char* expected[] = {"Gaston", "Matias", "Sebastian", "Daniela"};
-        		int i = 0;
-        		void _assert_names(char* name) {
-        			should_ptr(name) not be null;
-        		    should_string(name) be equal to (expected[i]);
-        		    i++;
-        		}
-        		string_iterate_lines(names, _assert_names);
-        	} end
+                char* expected[] = {"Gaston", "Matias", "Sebastian", "Daniela"};
+                int i = 0;
+                void _assert_names(char* name) {
+                    should_ptr(name) not be null;
+                    should_string(name) be equal to (expected[i]);
+                    i++;
+                }
+                string_iterate_lines(names, _assert_names);
+            } end
 
         } end
 
-		describe("Replace") {
-	        char* replaced;
+        describe("Replace") {
+            char* replaced;
 
-	        after {
-	        	free(replaced);
-	        } end
+            after {
+                free(replaced);
+            } end
 
-	        it ("replace multiple occurrences") {
-	        	replaced = string_replace("hexxo worxd!", "x", "l");
-	        	should_string(replaced) be equal to ("hello world!");
-	        } end
+            it ("replace multiple occurrences") {
+                replaced = string_replace("hexxo worxd!", "x", "l");
+                should_string(replaced) be equal to ("hello world!");
+            } end
 
-			it ("replace an occurrence with a longer one") {
-	        	replaced = string_replace("hello", "o", "o world!");
-	        	should_string(replaced) be equal to ("hello world!");
-	        } end
+            it ("replace an occurrence with a longer one") {
+                replaced = string_replace("hello", "o", "o world!");
+                should_string(replaced) be equal to ("hello world!");
+            } end
 
-			it ("replace an occurrence with a shorter one") {
-	        	replaced = string_replace("hello", "ello", "ola");
-	        	should_string(replaced) be equal to ("hola");
-	        } end
+            it ("replace an occurrence with a shorter one") {
+                replaced = string_replace("hello", "ello", "ola");
+                should_string(replaced) be equal to ("hola");
+            } end
 
-			it ("replace every occurrence with empty string") {
-	        	replaced = string_replace("hello", "l", "");
-	        	should_string(replaced) be equal to ("heo");
-	        } end
+            it ("replace every occurrence with empty string") {
+                replaced = string_replace("hello", "l", "");
+                should_string(replaced) be equal to ("heo");
+            } end
 
-			it ("replace duplicates original when doesn't receive a substring as pattern") {
-	        	replaced = string_replace("hello", "definitely not a substring", "test failed!");
-	        	should_string(replaced) be equal to ("hello");
-	        } end
+            it ("replace duplicates original when doesn't receive a substring as pattern") {
+                replaced = string_replace("hello", "definitely not a substring", "test failed!");
+                should_string(replaced) be equal to ("hello");
+            } end
 
-			it ("replace duplicates original when receives empty string as pattern") {
-	        	replaced = string_replace("hello", "", "test failed!");
-	        	should_string(replaced) be equal to ("hello");
-	        } end
+            it ("replace duplicates original when receives empty string as pattern") {
+                replaced = string_replace("hello", "", "test failed!");
+                should_string(replaced) be equal to ("hello");
+            } end
 
-	    } end
+        } end
 
     } end
 


### PR DESCRIPTION
Este PR incluye:
1. Fix del bug de `string_split` (https://github.com/sisoputnfrba/so-commons-library/issues/57) , ahora usa `strsep` en vez de `strtok_r`, lo cual permite que se comporte como se esperaba:

```
//Antes: 
string_split("//path//to/file/","/"); => { "path", "to","file", NULL }
string_split("", "/") => { NULL } 
//Ahora: 
string_split("//path//to/file/","/"); => { "", "", "path", "", "to", "file", "", NULL }
string_split("","/") => { "", NULL }
```

2. Un par de funciones muy sencillas para manejar arrays de strings:
    2.1. string_array_new
    2.2. string_array_size (https://github.com/sisoputnfrba/so-commons-library/issues/43) y string_array_is_empty
    2.3. string_array_push, pop y replace

Para hacer push, funciona igual que como se hace en el `_string_split` original: hace `realloc` cada vez que se agregue un elemento. Para hacer pop, solamente alcanza con reemplazar la posición en donde estaba por NULL (y se devuelve como en un list_remove).

3. Función `string_replace` (https://github.com/sisoputnfrba/so-commons-library/issues/59). Devuelve:

```
string_replace("hello", "ello", "ola") => "hola"
string_replace("hello", "l", "") => "heo"
string_replace("hello", "o", "o world!") => "hello world!"
string_replace("hello", "not a substring", "yay!") => "hello"
string_replace("hello", "", "x") => "hello"
string_replace("hello", NULL, "x") => error
string_replace(NULL, "a", "x") => error
```
