### PR TITLE
Refactor Temporal

### DIFF
--- a/src/commons/log.c
+++ b/src/commons/log.c
@@ -122,17 +122,17 @@ static void _log_write_in_level(t_log* logger, t_log_level level, const char* me
 		char *message, *time, *buffer, *console_buffer;
 		unsigned int thread_id;
 
-                message = string_from_vformat(message_template, list_arguments);
+		message = string_from_vformat(message_template, list_arguments);
 		time = temporal_get_string_time("%H:%M:%S:%MS");
 		thread_id = process_get_thread_id();
 
 		buffer = string_from_format("[%s] %s %s/(%d:%d): %s\n",
-                                log_level_as_string(level),
-                                time,
-                                logger->program_name,
-				logger->pid,
-                                thread_id,
-                                message);
+			log_level_as_string(level),
+			time,
+			logger->program_name,
+			logger->pid,
+			thread_id,
+			message);
 
 		if (logger->file != NULL) {
 			txt_write_in_file(logger->file, buffer);

--- a/src/commons/log.c
+++ b/src/commons/log.c
@@ -123,7 +123,7 @@ static void _log_write_in_level(t_log* logger, t_log_level level, const char* me
 		unsigned int thread_id;
 
                 message = string_from_vformat(message_template, list_arguments);
-		time = temporal_get_string_time();
+		time = temporal_get_string_time("%H:%M:%S:%MS");
 		thread_id = process_get_thread_id();
 
 		buffer = string_from_format("[%s] %s %s/(%d:%d): %s\n",

--- a/src/commons/temporal.h
+++ b/src/commons/temporal.h
@@ -19,8 +19,12 @@
 	/**
 	* @NAME: temporal_get_string_time
 	* @DESC: Retorna un string con la hora actual,
-	* con el siguiente formato: hh:mm:ss:mmmm
+	* con el formato recibido por parámetro.
+	* Ejemplos:
+	* temporal_get_string_time("%d/%m/%y") => "30/09/20"
+	* temporal_get_string_time("%H:%M:%S:%MS") => "12:51:59:331"
+	* temporal_get_string_time("%d/%m/%y %H:%M:%S") => "30/09/20 12:51:59"
 	*/
-	char *temporal_get_string_time();
+	char *temporal_get_string_time(const char* format);
 
 #endif /* TEMPORAL_H_ */

--- a/tests/integration-tests/logger/main.c
+++ b/tests/integration-tests/logger/main.c
@@ -7,12 +7,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <commons/log.h>
 #include <commons/string.h>
 #include <pthread.h>
 
 static void log_in_disk(char* temp_file) {
-    t_log* logger = log_create(temp_file, "TEST",true, LOG_LEVEL_INFO);
+    t_log* logger = log_create(temp_file, "TEST", true, LOG_LEVEL_INFO);
 
     log_trace(logger, "LOG A NIVEL %s", "TRACE");
     log_debug(logger, "LOG A NIVEL %s", "DEBUG");
@@ -21,16 +22,19 @@ static void log_in_disk(char* temp_file) {
     log_error(logger, "LOG A NIVEL %s", "ERROR");
 
     log_destroy(logger);
+    free(temp_file);
 }
 
 int main(int argc, char** argv) {
     pthread_t th1, th2;
     
-    char* temp_file = tmpnam(NULL);
+    char temp_file[] = "build/XXXXXX";
+
+    close(mkstemp(temp_file));
     
     if (temp_file != NULL) {
-        pthread_create(&th1, NULL, (void*) log_in_disk, temp_file);
-        pthread_create(&th2, NULL, (void*) log_in_disk, temp_file);
+        pthread_create(&th1, NULL, (void*) log_in_disk, string_duplicate(temp_file));
+        pthread_create(&th2, NULL, (void*) log_in_disk, string_duplicate(temp_file));
 
         pthread_join(th1, NULL);
         pthread_join(th2, NULL);

--- a/tests/integration-tests/temporal/main.c
+++ b/tests/integration-tests/temporal/main.c
@@ -7,64 +7,40 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <commons/txt.h>
 #include <commons/temporal.h>
 #include <commons/string.h>
 #include <pthread.h>
 
-static void log_in_disk(char* temp_file) {
-    FILE* file = txt_open_for_append(temp_file);
+static void print_time() {
+    char* date = temporal_get_string_time("day/month/year -- %d/%m/%y\n");
+    char* time = temporal_get_string_time("hour:min:sec:milisec -- %H:%M:%S:%MS\n");
 
-    char* day = temporal_get_string_time("day: %d\n");
-    char* month = temporal_get_string_time("month: %m\n");
-    char* year = temporal_get_string_time("year: %y\n");
+    txt_write_in_stdout(date);
+    txt_write_in_stdout(time);
 
-    char* hour = temporal_get_string_time("hour: %H\n");
-    char* min = temporal_get_string_time("min: %M\n");
-    char* sec = temporal_get_string_time("sec: %S\n");
-    char* milisec = temporal_get_string_time("milisec: %MS\n");
-
-    txt_write_in_file(file, day);
-    txt_write_in_file(file, month);
-    txt_write_in_file(file, year);
-
-    txt_write_in_file(file, hour);
-    txt_write_in_file(file, min);
-    txt_write_in_file(file, sec);
-    txt_write_in_file(file, milisec);
-
-    free(day);
-    free(month);
-    free(year);
-
-    free(hour);
-    free(min);
-    free(sec);
-    free(milisec);
-
-    txt_close_file(file);
-    free(temp_file);
+    free(date);
+    free(time);
 }
 
 int main(int argc, char** argv) {
-    pthread_t th1, th2;
-    
-    char temp_file[] = "build/XXXXXX";
+    pthread_t th1, th2, th3, th4, th5, th6;
 
-    close(mkstemp(temp_file));
+    printf("Verificar que fecha y hora sean correctas: \n");
 
-    if (temp_file != NULL) {
-        pthread_create(&th1, NULL, (void*) log_in_disk, string_duplicate(temp_file));
-        pthread_create(&th2, NULL, (void*) log_in_disk, string_duplicate(temp_file));
+    pthread_create(&th1, NULL, (void*) print_time, NULL);
+    pthread_create(&th2, NULL, (void*) print_time, NULL);
+    pthread_create(&th3, NULL, (void*) print_time, NULL);
+    pthread_create(&th4, NULL, (void*) print_time, NULL);
+    pthread_create(&th5, NULL, (void*) print_time, NULL);
+    pthread_create(&th6, NULL, (void*) print_time, NULL);
 
-        pthread_join(th1, NULL);
-        pthread_join(th2, NULL);
-        printf("\nRevisar el archivo de log que se creo en: %s\n", temp_file);
-    } else {
-        printf("No se pudo generar el archivo de log\n");
-    }
-    
+    pthread_join(th1, NULL);
+    pthread_join(th2, NULL);
+    pthread_join(th3, NULL);
+    pthread_join(th4, NULL);
+    pthread_join(th5, NULL);
+    pthread_join(th6, NULL);
     
     return (EXIT_SUCCESS);
 }

--- a/tests/integration-tests/temporal/main.c
+++ b/tests/integration-tests/temporal/main.c
@@ -1,0 +1,71 @@
+/* 
+ * File:   main.c
+ * Author: RaniAgus
+ *
+ * Created on March 24, 2020, 21:11 AM
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <commons/txt.h>
+#include <commons/temporal.h>
+#include <commons/string.h>
+#include <pthread.h>
+
+static void log_in_disk(char* temp_file) {
+    FILE* file = txt_open_for_append(temp_file);
+
+    char* day = temporal_get_string_time("day: %d\n");
+    char* month = temporal_get_string_time("month: %m\n");
+    char* year = temporal_get_string_time("year: %y\n");
+
+    char* hour = temporal_get_string_time("hour: %H\n");
+    char* min = temporal_get_string_time("min: %M\n");
+    char* sec = temporal_get_string_time("sec: %S\n");
+    char* milisec = temporal_get_string_time("milisec: %MS\n");
+
+    txt_write_in_file(file, day);
+    txt_write_in_file(file, month);
+    txt_write_in_file(file, year);
+
+    txt_write_in_file(file, hour);
+    txt_write_in_file(file, min);
+    txt_write_in_file(file, sec);
+    txt_write_in_file(file, milisec);
+
+    free(day);
+    free(month);
+    free(year);
+
+    free(hour);
+    free(min);
+    free(sec);
+    free(milisec);
+
+    txt_close_file(file);
+    free(temp_file);
+}
+
+int main(int argc, char** argv) {
+    pthread_t th1, th2;
+    
+    char temp_file[] = "build/XXXXXX";
+
+    close(mkstemp(temp_file));
+
+    if (temp_file != NULL) {
+        pthread_create(&th1, NULL, (void*) log_in_disk, string_duplicate(temp_file));
+        pthread_create(&th2, NULL, (void*) log_in_disk, string_duplicate(temp_file));
+
+        pthread_join(th1, NULL);
+        pthread_join(th2, NULL);
+        printf("\nRevisar el archivo de log que se creo en: %s\n", temp_file);
+    } else {
+        printf("No se pudo generar el archivo de log\n");
+    }
+    
+    
+    return (EXIT_SUCCESS);
+}
+

--- a/tests/integration-tests/temporal/makefile
+++ b/tests/integration-tests/temporal/makefile
@@ -1,7 +1,7 @@
 RM=rm -rf
 CC=gcc
 
-TAD=logger
+TAD=temporal
 BIN=build/commons-integration-test-$(TAD)
 
 C_SRCS=./main.c


### PR DESCRIPTION
Para el cuatri pasado me acuerdo que había que poner en el dump de la caché del Broker la fecha en formato `dd/mm/yy HH:MM:SS`. En su día tuve que hacer una función porque `temporal_get_string_time` solo admite un único formato para mostrar (que se usa solo para los loggers).

Solo funciona enviando los formatos que tienen el mismo tamaño que el token (lo cual me pareció suficiente): 
%d (día) %m (mes) %y (año en 2 dígitos) %H (horas 0-23) %M (minutos) %S (segundos) %MS (milisegundos, este último fue creado para poder mostrarlos de una forma más amigable).

Igualmente, se podría aprovechar la función `string_replace` que subí en otro PR para agregarle un par de formatos extra.

EDIT: Vi que al usar `ftime(3)` tira warning y se recomienda el uso de `clock_gettime(2)` ya que es más portable, así que lo cambié y ahora hace eso mismo.
https://man7.org/linux/man-pages/man3/ftime.3.html
https://man7.org/linux/man-pages/man2/clock_gettime.2.html