### PR TITLE
Nueva feature: readline

### DIFF
--- a/src/commons/txt.c
+++ b/src/commons/txt.c
@@ -17,7 +17,7 @@
 #include "txt.h"
 
 #include <stdlib.h>
-#include <commons/string.h>
+#include <string.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 

--- a/src/commons/txt.c
+++ b/src/commons/txt.c
@@ -33,8 +33,27 @@ void txt_write_in_file(FILE* file, char* bytes) {
 }
 
 void txt_write_in_stdout(char* string) {
-	printf("%s", string);
+	char *saved_line;
+    int saved_point;
+    int need_hack = (rl_readline_state & RL_STATE_READCMD) > 0;
+    if(need_hack) {
+        saved_point = rl_point;
+        saved_line = rl_copy_text(0, rl_end);
+        rl_save_prompt();
+        rl_replace_line("", 0);
+        rl_redisplay();
+    }
+
+    printf("%s", string);
 	fflush(stdout);
+
+    if(need_hack) {
+        rl_restore_prompt();
+        rl_replace_line(saved_line, 0);
+        rl_point = saved_point;
+        rl_redisplay();
+        free(saved_line);
+    }
 }
 
 void txt_close_file(FILE* file) {

--- a/src/commons/txt.c
+++ b/src/commons/txt.c
@@ -16,8 +16,12 @@
 
 #include "txt.h"
 
-#include <stdio.h>
+#include <stdlib.h>
+#include <commons/string.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 
+char** _get_tokens_array(char* line, int* argc);
 
 FILE* txt_open_for_append(char* path) {
 	return fopen(path, "a");
@@ -35,4 +39,49 @@ void txt_write_in_stdout(char* string) {
 
 void txt_close_file(FILE* file) {
 	fclose(file);
+}
+
+char** txt_read_line_in_stdin(const char* prompt, int* argc) {
+	char *line, **argv = NULL;
+	int args_count = 0;
+
+	line = readline(prompt);
+	if(line[0] != '\0') {
+		add_history(line);
+		argv = _get_tokens_array(line, &args_count);
+	}
+	free(line);
+
+	if(argc != NULL) {
+		*argc = args_count;
+	}
+
+	return argv;
+}
+
+char** _get_tokens_array(char* line, int* argc) {
+	char *buff, *token, **argv = NULL;
+
+	buff = line;
+	token = strtok_r(line, " ", &buff);
+
+	if(token != NULL) {
+		(*argc)++;
+		argv = realloc(argv, sizeof(char*) * (*argc));
+		argv[(*argc) - 1] = strdup(token);
+
+		while(buff[0] != '\0') {
+			token = strtok_r(NULL, " ", &buff);
+			if(token == NULL) {
+				break;
+			}
+			(*argc)++;
+			argv = realloc(argv, sizeof(char*) * (*argc));
+			argv[(*argc) - 1] = strdup(token);
+		}
+	}
+	argv = realloc(argv, sizeof(char*) * ((*argc) + 1));
+	argv[(*argc)] = NULL;
+
+	return argv;
 }

--- a/src/commons/txt.h
+++ b/src/commons/txt.h
@@ -38,6 +38,15 @@ void txt_write_in_file(FILE* file, char* string);
 void txt_write_in_stdout(char* string);
 
 /**
+* @NAME: txt_read_in_stdin
+* @DESC: Lee una línea desde la salida estandar y
+* retorna cada token en un array de strings, junto 
+* con su cantidad.
+* Retorna NULL en caso de recibir un salto de línea.
+*/
+char** txt_read_line_in_stdin(const char* prompt, int* argc);
+
+/**
 * @NAME: txt_close_file
 * @DESC: Cierra el archivo
 */

--- a/tests/integration-tests/logger/makefile
+++ b/tests/integration-tests/logger/makefile
@@ -11,7 +11,7 @@ create-dirs:
 	mkdir -p build/.
 
 build/commons-integration-test-logger: dependents create-dirs $(OBJS)
-	$(CC) -L"../../../src/build" -o "build/commons-integration-test-logger" $(OBJS) -lcommons -lpthread
+	$(CC) -L"../../../src/build" -o "build/commons-integration-test-logger" $(OBJS) -lcommons -lreadline -lpthread
 
 build/%.o: ./%.c
 	$(CC) -I"../../../src" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"

--- a/tests/unit-tests/makefile
+++ b/tests/unit-tests/makefile
@@ -13,7 +13,7 @@ create-dirs:
 	mkdir -p build
 
 build/commons-unit-test: dependents create-dirs $(OBJS)
-	$(CC) -L"../../src/build" -L"$(C_SPEC_BIN)" -o "build/commons-unit-test" $(OBJS) -lcommons -lcspecs
+	$(CC) -L"../../src/build" -L"$(C_SPEC_BIN)" -o "build/commons-unit-test" $(OBJS) -lcommons -lreadline -lcspecs
 
 build/%.o: ./%.c
 	$(CC) -I"../../src" -I"$(C_SPEC)" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"


### PR DESCRIPTION
Para el TP de este cuatri debemos incluir 2 consolas interactivas, y el problema que surgió fue que al querer llamar a la función `readline` mientras otros hilos están logueando mensajes en pantalla se me mezcla todo en el stdout de una forma que resulta, por lo menos, poco intuitiva:

![old](https://user-images.githubusercontent.com/39303639/94853613-07aa9e80-0402-11eb-8910-e171d0cc8a84.png)

Por lo tanto, lo que hice fue incluir en la función `txt_print_in_stdout` (función que usan los loggers) unas líneas de código que, de existir, guardan el prompt impreso por `readline` para que se loguee como siempre y, luego restauran el prompt guardado después del logueo:

![new](https://user-images.githubusercontent.com/39303639/94853820-53f5de80-0402-11eb-9f4f-f9334fb47cdc.png)

También incluyo la función `txt_read_line_in_stdin` que, a diferencia del `readline` original, devuelve un array de strings con lo ingresado y la cantidad de tokens (el resultado es el mismo que cuando se ejecuta enviando parámetros al `main`). Me está siendo muy útil para parsear argumentos en este TP.

La desventaja de lo incluido en este PR es que para usar las commons sí o sí hay que incluir el flag `-lreadline`, y quizás no sea la idea.