### PR TITLE
Listas: Insertar ordenado

### DIFF
--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -244,8 +244,8 @@ t_list* list_map(t_list* self, void*(*transformer)(void*)){
 int list_add_sorted(t_list *self, void* data, bool (*comparator)(void*,void*)) {
 	t_link_element* new_element = list_create_element(data);
 
-	bool _insert_element_sorted(void* element_data, int i) {
-		return !comparator(element_data, data);
+	bool _insert_element_sorted(t_link_element* element, int i) {
+		return element == NULL || !comparator(element->data, data);
 	}
 	return list_add_element(self, new_element, _insert_element_sorted);
 }

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -251,6 +251,15 @@ t_list* list_map(t_list* self, void*(*transformer)(void*)){
 	return mapped;
 }
 
+int list_add_sorted(t_list *self, void* data, bool (*comparator)(void*,void*)) {
+	t_link_element* new_element = list_create_element(data);
+
+	bool _insert_element_sorted(void* element_data, int i) {
+		return !comparator(element_data, data);
+	}
+	return list_add_element(self, new_element, _insert_element_sorted);
+}
+
 void list_sort(t_list *self, bool (*comparator)(void *, void *)) {
 	if(self->elements_count > 1) {
 		t_list* sorted = list_create();

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -57,6 +57,15 @@
 	void list_add_in_index(t_list *, int index, void *element);
 
 	/**
+	* @NAME: list_add_sorted
+	* @DESC: Agrega un elemento a una lista ordenada, manteniendo el
+	* orden definido por el comparador
+	* El comparador devuelve si el primer parametro debe aparecer antes que el
+	* segundo en la lista
+	*/
+	int list_add_sorted(t_list *self, void* data, bool (*comparator)(void*,void*));
+
+	/**
 	* @NAME: list_add_all
 	* @DESC: Agrega todos los elementos de
 	* la segunda lista en la primera

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -94,6 +94,23 @@ context (test_list) {
                 assert_person_in_list(list, 1, "Matias", 24);
             } end
 
+            it ("should add a value in sorted list") {
+                list_add(list, persona_create("Daniela" , 19));
+                list_add(list, persona_create("Matias"  , 24));
+                list_add(list, persona_create("Ezequiel", 25));
+                list_add(list, persona_create("Gaston"  , 25));
+
+                should_int(list_size(list)) be equal to(4);
+                list_add_sorted(list, persona_create("Sebastian", 21), (void*) _ayudantes_menor);
+                should_int(list_size(list)) be equal to(5);
+
+                assert_person_in_list(list, 0, "Daniela"  , 19);
+                assert_person_in_list(list, 1, "Sebastian", 21);
+                assert_person_in_list(list, 2, "Matias"   , 24);
+                assert_person_in_list(list, 3, "Ezequiel" , 25);
+                assert_person_in_list(list, 4, "Gaston"   , 25);
+            } end
+
             it("should add all list into other list") {
                 t_list* other = list_create();
 

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -95,20 +95,22 @@ context (test_list) {
             } end
 
             it ("should add a value in sorted list") {
-                list_add(list, persona_create("Daniela" , 19));
-                list_add(list, persona_create("Matias"  , 24));
-                list_add(list, persona_create("Ezequiel", 25));
-                list_add(list, persona_create("Gaston"  , 25));
+                list_add(list, persona_create("Sebastian", 21));
+                list_add(list, persona_create("Matias"   , 24));
+                list_add(list, persona_create("Gaston"   , 25));
 
-                should_int(list_size(list)) be equal to(4);
-                list_add_sorted(list, persona_create("Sebastian", 21), (void*) _ayudantes_menor);
-                should_int(list_size(list)) be equal to(5);
+                should_int(list_size(list)) be equal to(3);
+                list_add_sorted(list, persona_create("Daniela", 19), (void*) _ayudantes_menor);
+                list_add_sorted(list, persona_create("Agustin", 26), (void*) _ayudantes_menor);
+                list_add_sorted(list, persona_create("Ezequiel", 25), (void*) _ayudantes_menor);
+                should_int(list_size(list)) be equal to(6);
 
                 assert_person_in_list(list, 0, "Daniela"  , 19);
                 assert_person_in_list(list, 1, "Sebastian", 21);
                 assert_person_in_list(list, 2, "Matias"   , 24);
-                assert_person_in_list(list, 3, "Ezequiel" , 25);
-                assert_person_in_list(list, 4, "Gaston"   , 25);
+                assert_person_in_list(list, 3, "Gaston"   , 25);
+                assert_person_in_list(list, 4, "Ezequiel" , 25);
+                assert_person_in_list(list, 5, "Agustin"  , 26);
             } end
 
             it("should add all list into other list") {


### PR DESCRIPTION
Para desarrollar esta feature, me basé en el refactor en https://github.com/sisoputnfrba/so-commons-library/pull/126

Me pareció útil agregar un `add_sorted()` para las funciones de listas, que funciona utilizando el mismo tipo de comparador que se usa en `sort()` y `sorted()`:
```c
	/**
	* @NAME: list_add_sorted
	* @DESC: Agrega un elemento a una lista ordenada, manteniendo el
	* orden definido por el comparador
	* El comparador devuelve si el primer parametro debe aparecer antes que el
	* segundo en la lista
	*/
	int list_add_sorted(t_list *self, void* element, bool (*comparator)(void*,void*));
```