### PR TITLE
Listas: Splice y drop

### DIFF
--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -206,27 +206,33 @@ t_list* list_take(t_list* self, int count) {
 	return sublist;
 }
 
-t_list* list_take_and_remove(t_list* self, int count) {
+t_list* list_splice(t_list* self, int start, int count) {
+	if(start < 0) {
+		return list_splice(self, self->elements_count + start, count);
+	}
+	t_link_element* previous = NULL;
+	t_link_element* element = self->head;
+	for(int i = 0; i < start; i++) {
+		previous = element;
+		element = element->next;
+	}
 	t_list* sublist = list_create();
-	if(count > 0) {
-		sublist->head = self->head;
-		if(count < self->elements_count) {
-			t_link_element* last = self->head;
-			for(int i = 0; i < count - 1; i++) {
-				last = last->next;
-			}
-
-			self->head = last->next;
-			last->next = NULL;
-			sublist->elements_count = count;
-			self->elements_count -= count;
+	t_list* sublist_last_element = NULL;
+	for(int j = 0; j < count && element != NULL; j++) {
+		list_unlink_element(self, previous, element, start);
+		list_link_element(sublist, sublist_last_element, element, sublist->elements_count);
+		sublist_last_element = element;
+		if(start == 0) {
+			element = self->head;
 		} else {
-			self->head = NULL;
-			sublist->elements_count = self->elements_count;
-			self->elements_count = 0;
+			element = previous->next;
 		}
 	}
 	return sublist;
+}
+
+t_list* list_drop(t_list* self, int count) {
+	return count >= 0 ? list_splice(self, 0, count) : list_splice(self, 0, self->elements_count + count);
 }
 
 t_list* list_filter(t_list* self, bool(*condition)(void*)){

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -18,10 +18,13 @@
 
 #include "list.h"
 
-static void list_link_element(t_link_element* previous, t_link_element* next);
+static void list_link_element(t_list* self, t_link_element* previous, t_link_element* element, int index);
+static void list_unlink_element(t_list* self, t_link_element* previous,	t_link_element* element, int index);
 static t_link_element* list_create_element(void* data);
-static t_link_element* list_get_element(t_list* self, int index);
-static t_link_element* list_find_element(t_list *self, bool(*condition)(void*), int* index);
+static t_link_element* list_find_element(t_list *self, bool(*condition)(void*, int));
+static int list_add_element(t_list* self, t_link_element* element, bool(*condition)(void*, int));
+static t_link_element* list_remove_element(t_list *self, bool(*condition)(void*, int));
+static void list_add_to_sublist(t_list* sublist, t_list *self, bool(*condition)(void*, int), void* (*transformer)(void*));
 
 t_list *list_create() {
 	t_list *list = malloc(sizeof(t_list));
@@ -33,54 +36,49 @@ t_list *list_create() {
 int list_add(t_list *self, void *data) {
 	t_link_element *new_element = list_create_element(data);
 
-	if (self->elements_count == 0) {
-		self->head = new_element;
-	} else {
-		list_link_element(list_get_element(self, self->elements_count - 1), new_element);
+	bool _add_as_last(void* element_data, int i) {
+		return false;
 	}
-	self->elements_count++;
-	return self->elements_count - 1;
+	return list_add_element(self, new_element, _add_as_last);
 }
 
 void list_add_all(t_list* self, t_list* other) {
-	void _add_in_list(void* element){
-		list_add(self, element);
+	bool _add_all_elements(void* element_data, int index) {
+		return true;
 	}
-
-	list_iterate(other, _add_in_list);
+	list_add_to_sublist(self, other, _add_all_elements, NULL);
 }
 
 void* list_get(t_list *self, int index) {
-	t_link_element* element_in_index = list_get_element(self, index);
+	t_link_element* element_in_index;
+	bool _find_element_in_index(void* element_data, int i) {
+		return i == index;
+	}
+	element_in_index = list_find_element(self, _find_element_in_index);
+
 	return element_in_index != NULL ? element_in_index->data : NULL;
 }
 
 void list_add_in_index(t_list *self, int index, void *data) {
-	t_link_element* next = NULL;
-	t_link_element* new_element = NULL;
-	t_link_element* previous = NULL;
-
 	if ((self->elements_count >= index) && (index >= 0)) {
-		new_element = list_create_element(data);
+		t_link_element* new_element = list_create_element(data);
 
-		if (index == 0) {
-			list_link_element(new_element, self->head);
-			self->head = new_element;
-		} else {
-			next = list_get_element(self, index);
-			previous = list_get_element(self, index - 1);
-
-			list_link_element(previous, new_element);
-			list_link_element(new_element, next);
+		bool _add_element_at_index(void* element_data, int i) {
+			return i == index;
 		}
-		self->elements_count++;
+		list_add_element(self, new_element, _add_element_at_index);
 	}
 }
 
 void *list_replace(t_list *self, int index, void *data) {
 	void *old_data = NULL;
+	t_link_element* element;
 
-	t_link_element *element = list_get_element(self, index);
+	bool _find_element_at_index(void* element_data, int i) {
+		return i == index;
+	}
+	element = list_find_element(self, _find_element_at_index);
+
 	if (element != NULL) {
 		old_data = element->data;
 		element->data = data;
@@ -91,11 +89,18 @@ void *list_replace(t_list *self, int index, void *data) {
 
 void list_replace_and_destroy_element(t_list *self, int num, void *data, void(*element_destroyer)(void*)) {
 	void *old_data = list_replace(self, num, data);
-	element_destroyer(old_data);
+	if(old_data != NULL) {
+		element_destroyer(old_data);
+	}
 }
 
 void* list_find(t_list *self, bool(*condition)(void*)) {
-	t_link_element *element = list_find_element(self, condition, NULL);
+	t_link_element* element;
+	bool _find_by_condition(void* element_data, int i) {
+		return condition(element_data);
+	}
+	element = list_find_element(self, _find_by_condition);
+
 	return element != NULL ? element->data : NULL;
 }
 
@@ -111,45 +116,50 @@ void list_iterate(t_list* self, void(*closure)(void*)) {
 
 void *list_remove(t_list *self, int index) {
 	void *data = NULL;
-	t_link_element *aux_element = NULL;
+	t_link_element *element = NULL;
 
-	if (self->head == NULL) return NULL;
+	bool _remove_at_index(void* element_data, int i) {
+		return (i == index);
+	}
+	element = list_remove_element(self, _remove_at_index);
 
-	aux_element = list_get_element(self, index);
-	data = aux_element->data;
-
-	if (index == 0) {
-		self->head = aux_element->next;
-	} else {
-		t_link_element* previous = list_get_element(self, index - 1);
-		list_link_element(previous, aux_element->next);
+	if(element != NULL) {
+		data = element->data;
+		free(element);
 	}
 
-	self->elements_count--;
-	free(aux_element);
 	return data;
 }
 
 void* list_remove_by_condition(t_list *self, bool(*condition)(void*)) {
-	int index = 0;
+	t_link_element *element = NULL;
+	void *data = NULL;
 
-	t_link_element* element = list_find_element(self, condition, &index);
-	if (element != NULL) {
-		return list_remove(self, index);
+	bool _remove_by_condition(void* element_data, int i) {
+		return condition(element_data);
+	}
+	element = list_remove_element(self, _remove_by_condition);
+
+	if(element != NULL) {
+		data = element->data;
+		free(element);
 	}
 
-	return NULL;
+	return data;
 }
 
 void list_remove_and_destroy_element(t_list *self, int index, void(*element_destroyer)(void*)) {
 	void* data = list_remove(self, index);
-	element_destroyer(data);
+	if(data != NULL) {
+		element_destroyer(data);
+	}
 }
 
 void list_remove_and_destroy_by_condition(t_list *self, bool(*condition)(void*), void(*element_destroyer)(void*)) {
 	void* data = list_remove_by_condition(self, condition);
-	if (data)
+	if(data != NULL) {
 		element_destroyer(data);
+	}
 }
 
 int list_size(t_list *list) {
@@ -187,20 +197,34 @@ void list_destroy_and_destroy_elements(t_list *self, void(*element_destroyer)(vo
 
 t_list* list_take(t_list* self, int count) {
 	t_list* sublist = list_create();
-	int i = 0;
-	for (i = 0; i < count; ++i) {
-		void* element = list_get(self, i);
-		list_add(sublist, element);
+
+	bool _take_count_elements(void* element_data, int index) {
+		return index < count;
 	}
+	list_add_to_sublist(sublist, self, _take_count_elements, NULL);
+
 	return sublist;
 }
 
 t_list* list_take_and_remove(t_list* self, int count) {
 	t_list* sublist = list_create();
-	int i = 0;
-	for (i = 0; i < count; ++i) {
-		void* element = list_remove(self, 0);
-		list_add(sublist, element);
+	if(count > 0) {
+		sublist->head = self->head;
+		if(count < self->elements_count) {
+			t_link_element* last = self->head;
+			for(int i = 0; i < count - 1; i++) {
+				last = last->next;
+			}
+
+			self->head = last->next;
+			last->next = NULL;
+			sublist->elements_count = count;
+			self->elements_count -= count;
+		} else {
+			self->head = NULL;
+			sublist->elements_count = self->elements_count;
+			self->elements_count = 0;
+		}
 	}
 	return sublist;
 }
@@ -208,55 +232,46 @@ t_list* list_take_and_remove(t_list* self, int count) {
 t_list* list_filter(t_list* self, bool(*condition)(void*)){
 	t_list* filtered = list_create();
 
-	void _add_if_apply(void* element) {
-		if (condition(element)) {
-			list_add(filtered, element);
-		}
+	bool _add_if_condition(void* element_data, int index) {
+		return condition(element_data);
 	}
+	list_add_to_sublist(filtered, self, _add_if_condition, NULL);
 
-	list_iterate(self, _add_if_apply);
 	return filtered;
 }
 
 t_list* list_map(t_list* self, void*(*transformer)(void*)){
 	t_list* mapped = list_create();
 
-	void _add_after_transform(void* element) {
-		void* new_element = transformer(element);
-		list_add(mapped, new_element);
+	bool _transform_all(void* element_data, int index) {
+			return true;
 	}
+	list_add_to_sublist(mapped, self, _transform_all, transformer);
 
-	list_iterate(self, _add_after_transform);
 	return mapped;
 }
 
 void list_sort(t_list *self, bool (*comparator)(void *, void *)) {
-	// TODO: optimizar (usar un algoritmo mas copado)
-	int unsorted_elements = self->elements_count;
-	if(unsorted_elements < 2) {
-		return;
-	}
-	t_link_element *auxiliar = NULL;
-	bool sorted = true;
-	do {
-		t_link_element *previous_element = self->head, *cursor = previous_element->next;
-		sorted = true;
-		int index = 0, last_changed = unsorted_elements;
-		while(index < unsorted_elements && cursor != NULL) {
-			if(!comparator(previous_element->data, cursor->data)) {
-			   auxiliar = cursor->data;
-			   cursor->data = previous_element->data;
-			   previous_element->data = auxiliar;
-			   last_changed = index;
-			   sorted = false;
-			}
-			previous_element = cursor;
-			cursor = cursor->next;
-			index++;
-		}
-		unsorted_elements = last_changed;
-	} while(!sorted);
+	if(self->elements_count > 1) {
+		t_list* sorted = list_create();
+		t_link_element* removed = NULL;
 
+		while(self->elements_count > 0) {
+			bool _remove_first_element(void* element_data, int index) {
+				return true;
+			}
+			removed = list_remove_element(self,_remove_first_element);
+
+			bool _insert_element_sorted(void* element_data, int index) {
+				return !comparator(element_data, removed->data);
+			}
+			list_add_element(sorted, removed, _insert_element_sorted);
+		}
+
+		self->head = sorted->head;
+		self->elements_count = sorted->elements_count;
+		free(sorted);
+	}
 }
 
 t_list* list_sorted(t_list* self, bool (*comparator)(void *, void *)) {
@@ -266,9 +281,13 @@ t_list* list_sorted(t_list* self, bool (*comparator)(void *, void *)) {
 }
 
 int list_count_satisfying(t_list* self, bool(*condition)(void*)){
-	t_list *satisfying = list_filter(self, condition);
-	int result = satisfying->elements_count;
-	list_destroy(satisfying);
+	int result = 0;
+	void _count_satisfying(void* element_data) {
+		if(condition(element_data)) {
+			result++;
+		}
+	}
+	list_iterate(self, _count_satisfying);
 	return result;
 }
 
@@ -302,9 +321,26 @@ void* list_fold(t_list* self, void* seed, void*(*operation)(void*, void*))
 
 /********* PRIVATE FUNCTIONS **************/
 
-static void list_link_element(t_link_element* previous, t_link_element* next) {
-	if (previous != NULL) {
-		previous->next = next;
+static void list_link_element(t_list* self, t_link_element* previous, t_link_element* element, int index) {
+	if (index == 0) {
+		element->next = self->head;
+		self->head = element;
+	} else {
+		element->next = previous->next;
+		previous->next = element;
+	}
+	self->elements_count++;
+}
+
+static void list_unlink_element(t_list* self, t_link_element* previous,	t_link_element* element, int index) {
+	if (element != NULL) {
+		if (index == 0) {
+			self->head = element->next;
+		} else {
+			previous->next = element->next;
+		}
+		element->next = NULL;
+		self->elements_count--;
 	}
 }
 
@@ -315,32 +351,68 @@ static t_link_element* list_create_element(void* data) {
 	return element;
 }
 
-static t_link_element* list_get_element(t_list* self, int index) {
-	int cont = 0;
+static t_link_element* list_find_element(t_list *self, bool(*condition)(void*, int)) {
+	t_link_element* element = self->head;
+	int index = 0;
 
-	if ((self->elements_count > index) && (index >= 0)) {
-		t_link_element *element = self->head;
-		while (cont < index) {
-			element = element->next;
-			cont++;
-		}
-		return element;
-	}
-	return NULL;
-}
-
-static t_link_element* list_find_element(t_list *self, bool(*condition)(void*), int* index) {
-	t_link_element *element = self->head;
-	int position = 0;
-
-	while (element != NULL && !condition(element->data)) {
+	while(element != NULL && !(condition(element->data, index))) {
 		element = element->next;
-		position++;
-	}
-
-	if (index != NULL) {
-		*index = position;
+		index++;
 	}
 
 	return element;
+}
+
+static int list_add_element(t_list* self, t_link_element* element, bool(*condition)(void*, int)) {
+	t_link_element *previous = NULL;
+	t_link_element *aux = self->head;
+	int index = 0;
+
+	while(aux != NULL && !condition(aux->data, index)) {
+		previous = aux;
+		aux = aux->next;
+		index++;
+	}
+	list_link_element(self, previous, element, index);
+
+	return index;
+}
+
+static t_link_element* list_remove_element(t_list *self, bool(*condition)(void*, int)) {
+	t_link_element *previous = NULL;
+	t_link_element *element = self->head;
+	int index = 0;
+
+	while(element != NULL && !condition(element->data, index)) {
+		previous = element;
+		element = element->next;
+		index++;
+	}
+	list_unlink_element(self, previous, element, index);
+
+	return element;
+}
+
+static void list_add_to_sublist(t_list* sublist, t_list *self, bool(*condition)(void*, int), void* (*transformer)(void*)) {
+	bool _find_last_element(void* element_data, int i) {
+		return (i == sublist->elements_count - 1);
+	}
+	t_link_element* last_element = list_find_element(sublist, _find_last_element);
+	t_link_element* aux = self->head;
+	int index = 0;
+
+	while(aux != NULL) {
+		if(condition(aux->data, index)) {
+			t_link_element* new_element;
+			if(transformer == NULL) {
+				new_element = list_create_element(aux->data);
+			} else {
+				new_element = list_create_element(transformer(aux->data));
+			}
+			list_link_element(sublist, last_element, new_element, sublist->elements_count);
+			last_element = new_element;
+		}
+		index++;
+		aux = aux->next;
+	}
 }

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -77,12 +77,21 @@
 	t_list* list_take(t_list*, int count);
 
 	/**
-	* @NAME: list_take_and_remove
-	* @DESC: Retorna una nueva lista con
-	* los primeros n elementos, eliminando
-	* del origen estos elementos
+	* @NAME: list_drop
+	* @DESC: Retorna una nueva lista con los primeros n elementos, eliminando
+	* del origen estos elementos. Si n es negativo, retorna y elimina todos 
+	* excepto los -n últimos.
 	*/
-	t_list* list_take_and_remove(t_list*, int count);
+	t_list* list_drop(t_list*, int count);
+
+	/**
+	* @NAME: list_splice
+	* @DESC: Retorna una nueva lista con los
+	* primeros n elementos partiendo desde el 
+	* índice indicado, eliminando del origen
+	* estos elementos
+	*/
+	t_list* list_splice(t_list* self, int start, int count);
 
 	/**
 	* @NAME: list_filter

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -273,13 +273,49 @@ context (test_list) {
             } end
 
             it("should return a new list with the first \"N\" elements of a list and remove them from original list") {
-                t_list* sublist = list_take_and_remove(list, 3);
+                t_list* sublist = list_drop(list, 3);
                 should_int(list_size(list)) be equal to(2);
                 should_int(list_size(sublist)) be equal to(3);
 
                 assert_person_in_list(sublist, 0, "Matias"   , 24);
                 assert_person_in_list(sublist, 1, "Gaston"   , 25);
                 assert_person_in_list(sublist, 2, "Sebastian", 21);
+
+                list_destroy_and_destroy_elements(sublist, (void*)persona_destroy);
+            } end
+
+            it("should return a new list with all elements except the last \"N\" and remove them from original list") {
+                t_list* sublist = list_drop(list, -2);
+                should_int(list_size(list)) be equal to(2);
+                should_int(list_size(sublist)) be equal to(3);
+
+                assert_person_in_list(sublist, 0, "Matias"   , 24);
+                assert_person_in_list(sublist, 1, "Gaston"   , 25);
+                assert_person_in_list(sublist, 2, "Sebastian", 21);
+
+                list_destroy_and_destroy_elements(sublist, (void*)persona_destroy);
+            } end
+
+            it("should return a new list with \"N\" elements starting at a given index and remove them from the original list") {
+                t_list* sublist = list_splice(list, 1, 3);
+                should_int(list_size(list)) be equal to(2);
+                should_int(list_size(sublist)) be equal to(3);
+
+                assert_person_in_list(sublist, 0, "Gaston"   , 25);
+                assert_person_in_list(sublist, 1, "Sebastian", 21);
+                assert_person_in_list(sublist, 2, "Ezequiel" , 25);
+
+                list_destroy_and_destroy_elements(sublist, (void*)persona_destroy);
+            } end
+
+            it("should return a new list with the remaining elements starting at a given index and remove them from the original list when \"N\" is too big") {
+                t_list* sublist = list_splice(list, 2, 10);
+                should_int(list_size(list)) be equal to(2);
+                should_int(list_size(sublist)) be equal to(3);
+
+                assert_person_in_list(sublist, 0, "Sebastian", 21);
+                assert_person_in_list(sublist, 1, "Ezequiel" , 25);
+                assert_person_in_list(sublist, 2, "Facundo"  , 25);
 
                 list_destroy_and_destroy_elements(sublist, (void*)persona_destroy);
             } end

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -40,7 +40,11 @@ static void persona_destroy(t_person *self) {
 }
 
 static bool _ayudantes_menor(t_person *joven, t_person *menos_joven) {
-    return joven->age < menos_joven->age;
+    return joven->age <= menos_joven->age;
+}
+
+static bool _ayudantes_alfabetico(t_person *primero, t_person *segundo) {
+    return strcmp(primero->name, segundo->name) <= 0;
 }
 
 context (test_list) {
@@ -205,14 +209,14 @@ context (test_list) {
                 list_add(list, persona_create("Facundo"  , 25));
             } end
 
-            it(" should find the first value that satisfies a condition") {
-            	t_person *find_someone_by_name(char *name) {
-            		int _is_the_one(t_person *p) {
-            			return string_equals_ignore_case(p->name, name);
-            		}
+            it("should find the first value that satisfies a condition") {
+                t_person *find_someone_by_name(char *name) {
+                    int _is_the_one(t_person *p) {
+                        return string_equals_ignore_case(p->name, name);
+                    }
 
-            		return list_find(list, (void*) _is_the_one);
-            	}
+                    return list_find(list, (void*) _is_the_one);
+                }
 
                 assert_person(find_someone_by_name("Ezequiel"), "Ezequiel", 25);
                 assert_person(find_someone_by_name("Sebastian"), "Sebastian", 21);
@@ -314,8 +318,25 @@ context (test_list) {
                     assert_person_in_list(a_sorted_list, 0, "Daniela"  , 19);
                     assert_person_in_list(a_sorted_list, 1, "Sebastian", 21);
                     assert_person_in_list(a_sorted_list, 2, "Matias"   , 24);
+                    assert_person_in_list(a_sorted_list, 3, "Gaston"   , 25);
+                    assert_person_in_list(a_sorted_list, 4, "Ezequiel" , 25);
+                }
+
+                void _verify_a_sort_with_multiple_comparators(t_list* (*sorted_list_generator)()) {
+                	list_add(list, persona_create("Ezequiel", 25));
+                    list_add(list, persona_create("Julian"  , 25));
+                    list_add(list, persona_create("Facundo" , 25));
+                    list_sort(list, (void*) _ayudantes_alfabetico);
+
+                    t_list* a_sorted_list = sorted_list_generator();
+
+                    assert_person_in_list(a_sorted_list, 0, "Daniela"  , 19);
+                    assert_person_in_list(a_sorted_list, 1, "Sebastian", 21);
+                    assert_person_in_list(a_sorted_list, 2, "Matias"   , 24);
                     assert_person_in_list(a_sorted_list, 3, "Ezequiel" , 25);
-                    assert_person_in_list(a_sorted_list, 4, "Gaston"   , 25);
+                    assert_person_in_list(a_sorted_list, 4, "Facundo"  , 25);
+                    assert_person_in_list(a_sorted_list, 5, "Gaston"   , 25);
+                    assert_person_in_list(a_sorted_list, 6, "Julian"   , 25);
                 }
 
                 before {
@@ -341,6 +362,10 @@ context (test_list) {
                         _verify_a_sort_with_duplicates(__sorted_list);
                     } end
 
+                    it("should sort a list with multiple comparators") {
+                        _verify_a_sort_with_multiple_comparators(__sorted_list);
+                    } end
+
                 } end
 
                 describe ("Sorted - without side effect") {
@@ -362,6 +387,10 @@ context (test_list) {
 
                     it("should sort a list with duplicated values") {
                         _verify_a_sort_with_duplicates(__sorted_list);
+                    } end
+
+                    it("should sort a list with multiple comparators") {
+                        _verify_a_sort_with_multiple_comparators(__sorted_list);
                     } end
 
                 } end
@@ -462,7 +491,7 @@ context (test_list) {
                 should_int(index) be equal to(4);
             } end
 
-        } end        
+        } end
 
         describe ("Fold") {
 


### PR DESCRIPTION
Para desarrollar esta feature, me basé en el refactor en #126

Agrego la función `list_splice`, emulando el comportamiento de [Array splice en JS](https://www.w3schools.com/jsref/jsref_splice.asp):

```
	/**
	* @NAME: list_splice
	* @DESC: Retorna una nueva lista con los
	* primeros n elementos partiendo desde el 
	* índice indicado, eliminando del origen
	* estos elementos
	*/
```
Y también cambio la firma de `list_take_and_remove`, la renombro como `list_drop`  y hago que sea como un `list_splice` más específico, además de que tiene un comportamiento determinado si recibe un valor negativo:

```
	/**
	* @NAME: list_drop
	* @DESC: Retorna una nueva lista con los primeros n elementos, eliminando
	* del origen estos elementos. Si n es negativo, retorna y elimina todos 
	* excepto los -n últimos.
	*/
```
Si bien [drop en Haskell](http://zvon.org/other/haskell/Outputprelude/drop_f.html) sería como un "take, remove and destroy", creo que el cambio de nombre suena mejor. Díganme si lo prefieren así y sino lo vuelvo atrás a como estaba.