### PR TITLE
Strings: Fix string_split

### DIFF
--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -51,7 +51,7 @@ t_config *config_create(char *path) {
 	char** lines = string_split(buffer, "\n");
 
 	void add_cofiguration(char *line) {
-		if (!string_starts_with(line, "#")) {
+		if (!string_is_empty(line) && !string_starts_with(line, "#")) {
 			char** keyAndValue = string_n_split(line, 2, "=");
 			dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
 			free(keyAndValue[0]);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -159,13 +159,13 @@ char** string_n_split(char *text, int n, char* separator) {
 
 char**  string_get_string_as_array(char* text) {
 	int length_value = strlen(text) - 2;
+	if (length_value == 0) return calloc(1, sizeof(char*));
+
 	char* value_without_brackets = string_substring(text, 1, length_value);
 	char **array_values = string_split(value_without_brackets, ",");
 
-	int i = 0;
-	while (array_values[i] != NULL) {
+	for (int i = 0; array_values[i] != NULL; i++) {
 		string_trim(&(array_values[i]));
-		i++;
 	}
 
 	free(value_without_brackets);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -145,14 +145,14 @@ bool string_equals_ignore_case(char *actual, char *expected) {
 
 char **string_split(char *text, char *separator) {
 	bool _is_last_token(char* next, int _) {
-		return next[0] != '\0';
+		return next != NULL;
 	}
 	return _string_split(text, separator, _is_last_token);
 }
 
 char** string_n_split(char *text, int n, char* separator) {
 	bool _is_last_token(char* next, int index) {
-		return next[0] != '\0' && index < (n - 1);
+		return next != NULL && index < (n - 1);
 	}
 	return _string_split(text, separator, _is_last_token);
 }
@@ -252,22 +252,19 @@ char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) 
 	int size = 0;
 
 	char *text_to_iterate = string_duplicate(text);
-
 	char *next = text_to_iterate;
-	char *str = text_to_iterate;
 
 	while(condition(next, size)) {
-		char* token = strtok_r(str, separator, &next);
+		char* token = strsep(&next, separator);
 		if(token == NULL) {
 			break;
 		}
-		str = NULL;
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(token);
 	};
 
-	if (next[0] != '\0') {
+	if (next != NULL) {
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(next);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -67,7 +67,7 @@ char* string_from_vformat(const char* format, va_list arguments) {
 }
 
 char* string_itoa(int number) {
-    return string_from_format("%d", number);
+	return string_from_format("%d", number);
 }
 
 void string_append_with_format(char **original, const char *format, ...) {
@@ -158,21 +158,21 @@ char** string_n_split(char *text, int n, char* separator) {
 }
 
 char**  string_get_string_as_array(char* text) {
-    int length_value = strlen(text) - 2;
-    char* value_without_brackets = string_substring(text, 1, length_value);
-    char **array_values = string_split(value_without_brackets, ",");
+	int length_value = strlen(text) - 2;
+	char* value_without_brackets = string_substring(text, 1, length_value);
+	char **array_values = string_split(value_without_brackets, ",");
 
-    int i = 0;
-    while (array_values[i] != NULL) {
-	    string_trim(&(array_values[i]));
-	    i++;
-    }
+	int i = 0;
+	while (array_values[i] != NULL) {
+		string_trim(&(array_values[i]));
+		i++;
+	}
 
-    free(value_without_brackets);
-    return array_values;
+	free(value_without_brackets);
+	return array_values;
 }
 
-char*   string_substring(char* text, int start, int length) {
+char* string_substring(char* text, int start, int length) {
 	char* new_string = calloc(1, length + 1);
 	strncpy(new_string, text + start, length);
 	return new_string;
@@ -198,19 +198,19 @@ int string_length(char* text) {
 }
 
 char* string_reverse(char* palabra) {
-    char* resultado = calloc(1, string_length(palabra) + 1);
+	char* resultado = calloc(1, string_length(palabra) + 1);
 
-    int i = string_length(palabra) - 1, j = 0;
-    while (i >= 0){
-        resultado[j] = palabra[i];
-        i--;
-        j++;
-    }
+	int i = string_length(palabra) - 1, j = 0;
+	while (i >= 0){
+	resultado[j] = palabra[i];
+		i--;
+		j++;
+	}
 
-    return resultado;
+	return resultado;
 }
 
-bool	string_contains(char* text, char *substring) {
+bool string_contains(char* text, char *substring) {
 	return strstr(text, substring) != NULL;
 }
 

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -30,7 +30,7 @@
 	* @NAME: string_itoa
 	* @DESC: Crea un string a partir de un numero
 	*/
-	char* string_itoa(int number);
+	char*   string_itoa(int number);
 
 	/**
 	* @NAME: string_from_format
@@ -71,7 +71,7 @@
 	*
 	* => unaPalabra = "HOLA PEPE"
 	*/
-	void 	string_append(char ** original, char * string_to_add);
+	void    string_append(char ** original, char * string_to_add);
 
 	/**
 	* @NAME: string_append_with_format
@@ -93,58 +93,58 @@
 	* @DESC: Retorna una copia del string pasado
 	* como argumento
 	*/
-	char*	string_duplicate(char* original);
+	char*   string_duplicate(char* original);
 
 	/**
 	* @NAME: string_to_upper
 	* @DESC: Pone en mayuscula todos los caracteres de un string
 	*/
-	void 	string_to_upper(char * text);
+	void    string_to_upper(char * text);
 
 	/**
 	* @NAME: string_to_lower
 	* @DESC: Pone en minuscula todos los caracteres de un string
 	*/
-	void 	string_to_lower(char * text);
+	void    string_to_lower(char * text);
 
 	/**
 	* @NAME: string_capitalized
 	* @DESC: Capitaliza un string
 	*/
-	void 	string_capitalized(char * text);
+	void    string_capitalized(char * text);
 
 	/**
 	* @NAME: string_trim
 	* @DESC: Remueve todos los caracteres
 	* vacios de la derecha y la izquierda
 	*/
-	void 	string_trim(char ** text);
+	void    string_trim(char ** text);
 
 	/**
 	* @NAME: string_trim_left
 	* @DESC: Remueve todos los caracteres
 	* vacios de la izquierda
 	*/
-	void 	string_trim_left(char ** text);
+	void    string_trim_left(char ** text);
 
 	/**
 	* @NAME: string_trim_right
 	* @DESC: Remueve todos los caracteres
 	* vacios de la derecha
 	*/
-	void 	string_trim_right(char ** text);
+	void    string_trim_right(char ** text);
 
 	/**
 	* @NAME: string_length
 	* @DESC: Retorna la longitud del string
 	*/
-	int 	string_length(char * text);
+	int     string_length(char * text);
 
 	/**
 	* @NAME: string_is_empty
 	* @DESC: Retorna si un string es ""
 	*/
-	bool 	string_is_empty(char * text);
+	bool    string_is_empty(char * text);
 
 	/**
 	* @NAME: string_starts_with
@@ -152,7 +152,7 @@
 	* si un string comienza con el
 	* string pasado por parametro
 	*/
-	bool 	string_starts_with(char * text, char * begin);
+	bool    string_starts_with(char * text, char * begin);
 
 	/**
 	* @NAME: string_ends_with
@@ -160,14 +160,14 @@
 	* si un string finaliza con el
 	* string pasado por parametro
 	*/
-	bool	string_ends_with(char* text, char* end);
+	bool    string_ends_with(char* text, char* end);
 
 	/**
 	* @NAME: string_equals_ignore_case
 	* @DESC: Retorna si dos strings son iguales
 	* ignorando las mayusculas y minusculas
 	*/
-	bool 	string_equals_ignore_case(char * actual, char * expected);
+	bool    string_equals_ignore_case(char * actual, char * expected);
 
 	/**
 	* @NAME: string_split
@@ -218,7 +218,7 @@
 	* @DESC: Itera un array de strings aplicando
 	* el closure a cada string, hasta que encuentre un NULL
 	*/
-	void 	string_iterate_lines(char ** strings, void (*closure)(char *));
+	void    string_iterate_lines(char ** strings, void (*closure)(char *));
 
 	/**
 	* @NAME: string_get_string_as_array
@@ -240,13 +240,13 @@
 	 * char* original = "boo";
 	 * string_reverse(original) => "oob"
 	 */
-	char*	string_reverse(char* text);
+	char*   string_reverse(char* text);
 
 	/**
 	 * @NAME: string_contains
 	 * @DESC: Retorna un boolean que indica si text contiene o no
 	 * a substring.
 	 */
-	bool	string_contains(char* text, char *substring);
+	bool    string_contains(char* text, char *substring);
 
 #endif /* STRING_UTILS_H_ */

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -89,8 +89,8 @@ context (test_config) {
                     should_string(config_get_string_value(config, "EMPTY_ARRAY")) be equal to("[]");
                     char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
 
-                    char* empty_array_expected[] = {"", NULL};
-                    _assert_equals_array(empty_array_expected, empty_array, 1);
+                    char* empty_array_expected[] = {NULL};
+                    _assert_equals_array(empty_array_expected, empty_array, 0);
 
                     string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -89,8 +89,10 @@ context (test_config) {
                     should_string(config_get_string_value(config, "EMPTY_ARRAY")) be equal to("[]");
                     char** empty_array  = config_get_array_value(config, "EMPTY_ARRAY");
 
-                    char* empty_array_expected[] = {NULL};
-                    _assert_equals_array(empty_array_expected, empty_array, 0);
+                    char* empty_array_expected[] = {"", NULL};
+                    _assert_equals_array(empty_array_expected, empty_array, 1);
+
+                    string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);
                 } end
 

--- a/tests/unit-tests/test_config.c
+++ b/tests/unit-tests/test_config.c
@@ -37,15 +37,15 @@ context (test_config) {
         describe ("Inexistent file") {
 
             it ("should return null when try to open a non-existent config file") {
-            	t_config *config = config_create("this_doesnt_exist.really.dont.cfg");
+                t_config *config = config_create("this_doesnt_exist.really.dont.cfg");
                 should_ptr(config) be null;
             } end
 
         } end
 
-		describe ("Existent file") {
+        describe ("Existent file") {
 
-        	t_config* config;
+            t_config* config;
 
             before {
                 config = config_create("resources/config.cfg");
@@ -166,10 +166,10 @@ context (test_config) {
             config = config_create("resources/config.cfg");
         } end
 
-    	after {
+        after {
             remove(new_file_path);
             config_destroy(config);
-    	} end
+        } end
 
         it ("should create a file with the specified config") {
             int result = config_save_in_file(config, new_file_path);
@@ -177,7 +177,7 @@ context (test_config) {
             should_int(access(new_file_path, F_OK)) be equal to (0);
         } end
 
-    	it ("should override a config") {
+        it ("should override a config") {
             char* key = "PORT";
             char* expected = "3000";
             config_set_value(config, key, expected);
@@ -185,7 +185,7 @@ context (test_config) {
             t_config *new_config = config_create(new_file_path);
             should_string(config_get_string_value(new_config, key)) be equal to (expected);
             config_destroy(new_config);    	    
-    	} end
+        } end
 
         it ("should create a config file without the specified key") {
             char* key = "PORT";

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -205,6 +205,7 @@ context (test_string) {
                 should_string(substrings[1]) be equal to ("path");
                 should_string(substrings[2]) be equal to ("to");
                 should_string(substrings[3]) be equal to ("file");
+                should_ptr(substrings[4]) be null;
 
                 string_iterate_lines(substrings, (void*) free);
                 free(substrings);
@@ -219,6 +220,7 @@ context (test_string) {
                 should_string(substrings[1]) be equal to ("to");
                 should_string(substrings[2]) be equal to ("file");
                 should_string(substrings[3]) be equal to ("");
+                should_ptr(substrings[4]) be null;
 
                 string_iterate_lines(substrings, (void*) free);
                 free(substrings);
@@ -233,6 +235,7 @@ context (test_string) {
                 should_string(substrings[1]) be equal to ("to");
                 should_string(substrings[2]) be equal to ("");
                 should_string(substrings[3]) be equal to ("file");
+                should_ptr(substrings[4]) be null;
 
                 string_iterate_lines(substrings, (void*) free);
                 free(substrings);
@@ -244,6 +247,7 @@ context (test_string) {
 
                 should_ptr(substrings) not be null;
                 should_string(substrings[0]) be equal to("");
+                should_ptr(substrings[1]) be null;
 
                 string_iterate_lines(substrings, (void*) free);
                 free(substrings);

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -426,7 +426,7 @@ context (test_string) {
                     char* string_empty_array = "[]";
                     char** empty_array = string_get_string_as_array(string_empty_array);
                     should_ptr(empty_array) not be null;
-                    should_string(empty_array[0]) be equal to("");
+                    should_ptr(empty_array[0]) be null;
 
                     string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -182,8 +182,8 @@ context (test_string) {
 
         describe("Split") {
 
-        	it("split_with_delimitators") {
-        		char *line = "path/to/file";
+            it("split_with_delimitators") {
+                char *line = "path/to/file";
                 char** substrings = string_split(line, "/");
 
                 should_ptr(substrings) not be null;
@@ -192,51 +192,51 @@ context (test_string) {
                 should_string(substrings[2]) be equal to ("file");
                 should_ptr(substrings[3]) be null;
 
-				string_iterate_lines(substrings, (void*) free);
+                string_iterate_lines(substrings, (void*) free);
                 free(substrings);
             } end
 
-			it("split_starting_with_delimitator") {
-              	char* line = "/path/to/file";
-				char** substrings = string_split(line, "/");
+            it("split_starting_with_delimitator") {
+                char* line = "/path/to/file";
+                char** substrings = string_split(line, "/");
 
-				should_ptr(substrings) not be null;
-				should_string(substrings[0]) be equal to ("");
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("");
                 should_string(substrings[1]) be equal to ("path");
                 should_string(substrings[2]) be equal to ("to");
                 should_string(substrings[3]) be equal to ("file");
 
-				string_iterate_lines(substrings, (void*) free);
-				free(substrings);
-			} end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-			it("split_ending_with_delimitator") {
-				char* line = "path/to/file/";
-				char** substrings = string_split(line, "/");
+            it("split_ending_with_delimitator") {
+                char* line = "path/to/file/";
+                char** substrings = string_split(line, "/");
 
-				should_ptr(substrings) not be null;
+                should_ptr(substrings) not be null;
                 should_string(substrings[0]) be equal to ("path");
                 should_string(substrings[1]) be equal to ("to");
                 should_string(substrings[2]) be equal to ("file");
-			    should_string(substrings[3]) be equal to ("");
+                should_string(substrings[3]) be equal to ("");
 
-			    string_iterate_lines(substrings, (void*) free);
-				free(substrings);
-			} end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-			it("split_having_delimitators_in_between") {
-				char* line = "path/to//file";
-			    char** substrings = string_split(line, "/");
+            it("split_having_delimitators_in_between") {
+                char* line = "path/to//file";
+                char** substrings = string_split(line, "/");
 
-			    should_ptr(substrings) not be null;
+                should_ptr(substrings) not be null;
                 should_string(substrings[0]) be equal to ("path");
                 should_string(substrings[1]) be equal to ("to");
-			    should_string(substrings[2]) be equal to ("");
+                should_string(substrings[2]) be equal to ("");
                 should_string(substrings[3]) be equal to ("file");
 
-			    string_iterate_lines(substrings, (void*) free);
-				free(substrings);
-			} end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
             it("split_is_empty") {
                 char* line = "";

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -182,95 +182,137 @@ context (test_string) {
 
         describe("Split") {
 
-                it("split_with_delimitators") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_split(line, " ");
+        	it("split_with_delimitators") {
+        		char *line = "path/to/file";
+                char** substrings = string_split(line, "/");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta");
-                    should_string(substrings[2]) be equal to("tierra");
-                    should_ptr(substrings[3]) be null;
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path");
+                should_string(substrings[1]) be equal to ("to");
+                should_string(substrings[2]) be equal to ("file");
+                should_ptr(substrings[3]) be null;
 
-                    free(substrings[0]);
-                    free(substrings[1]);
-                    free(substrings[2]);
-                    free(substrings);
-                } end
+				string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-                it("split_is_empty") {
-                    char* line = "";
-                    char** substrings = string_split(line, ";");
+			it("split_starting_with_delimitator") {
+              	char* line = "/path/to/file";
+				char** substrings = string_split(line, "/");
 
-                    should_ptr(substrings) not be null;
-                    should_ptr(substrings[0]) be null;
+				should_ptr(substrings) not be null;
+				should_string(substrings[0]) be equal to ("");
+                should_string(substrings[1]) be equal to ("path");
+                should_string(substrings[2]) be equal to ("to");
+                should_string(substrings[3]) be equal to ("file");
 
-                    free(substrings);
+				string_iterate_lines(substrings, (void*) free);
+				free(substrings);
+			} end
 
-                } end
+			it("split_ending_with_delimitator") {
+				char* line = "path/to/file/";
+				char** substrings = string_split(line, "/");
 
-                it("n_split_when_n_is_less_than_splitted_elements") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_n_split(line, 2, " ");
+				should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path");
+                should_string(substrings[1]) be equal to ("to");
+                should_string(substrings[2]) be equal to ("file");
+			    should_string(substrings[3]) be equal to ("");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta tierra");
-                    should_ptr(substrings[2]) be null;
+			    string_iterate_lines(substrings, (void*) free);
+				free(substrings);
+			} end
 
-                    string_iterate_lines(substrings, (void*) free);
-                    free(substrings);
-                } end
+			it("split_having_delimitators_in_between") {
+				char* line = "path/to//file";
+			    char** substrings = string_split(line, "/");
 
-                it("n_split_when_n_is_equals_than_splitted_elements") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_n_split(line, 3, " ");
+			    should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path");
+                should_string(substrings[1]) be equal to ("to");
+			    should_string(substrings[2]) be equal to ("");
+                should_string(substrings[3]) be equal to ("file");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta");
-                    should_string(substrings[2]) be equal to("tierra");
-                    should_ptr(substrings[3]) be null;
+			    string_iterate_lines(substrings, (void*) free);
+				free(substrings);
+			} end
 
-                    string_iterate_lines(substrings, (void*) free);
-                    free(substrings);
-                } end
+            it("split_is_empty") {
+                char* line = "";
+                char** substrings = string_split(line, "/");
 
-                it("n_split_when_separator_isnt_included") {
-                    char *line = "Hola planeta tierra";
-                    char ** substrings = string_n_split(line, 5, ";");
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to(line);
-                    should_ptr(substrings[1]) be null;
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
 
-                    string_iterate_lines(substrings, (void *) free);
-                    free(substrings);
-                } end
+            } end
 
-                it("n_split_when_n_is_greather_than_splitted_elements") {
-                    char *line = "Hola planeta tierra";
-                    char** substrings = string_n_split(line, 10, " ");
+            it("n_split_when_n_is_less_than_splitted_elements") {
+                char *line = "Hola planeta tierra";
+                char** substrings = string_n_split(line, 2, " ");
 
-                    should_ptr(substrings) not be null;
-                    should_string(substrings[0]) be equal to("Hola");
-                    should_string(substrings[1]) be equal to("planeta");
-                    should_string(substrings[2]) be equal to("tierra");
-                    should_ptr(substrings[3]) be null;
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("Hola");
+                should_string(substrings[1]) be equal to("planeta tierra");
+                should_ptr(substrings[2]) be null;
 
-                    string_iterate_lines(substrings, (void*) free);
-                    free(substrings);
-                } end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
-                it("n_split_is_empty") {
-                    char* line = "";
-                    char** substrings = string_n_split(line, 10, ";");
+            it("n_split_when_n_is_equals_than_splitted_elements") {
+                char *line = "Hola planeta tierra";
+                char** substrings = string_n_split(line, 3, " ");
 
-                    should_ptr(substrings) not be null;
-                    should_ptr(substrings[0]) be null;
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("Hola");
+                should_string(substrings[1]) be equal to("planeta");
+                should_string(substrings[2]) be equal to("tierra");
+                should_ptr(substrings[3]) be null;
 
-                    free(substrings);
-                } end
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
+
+            it("n_split_when_separator_isnt_included") {
+                char *line = "Hola planeta tierra";
+                char ** substrings = string_n_split(line, 5, ";");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to(line);
+                should_ptr(substrings[1]) be null;
+
+                string_iterate_lines(substrings, (void *) free);
+                free(substrings);
+            } end
+
+            it("n_split_when_n_is_greather_than_splitted_elements") {
+                char *line = "Hola planeta tierra";
+                char** substrings = string_n_split(line, 10, " ");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("Hola");
+                should_string(substrings[1]) be equal to("planeta");
+                should_string(substrings[2]) be equal to("tierra");
+                should_ptr(substrings[3]) be null;
+
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
+
+            it("n_split_is_empty") {
+                char* line = "";
+                char** substrings = string_n_split(line, 10, ";");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("");
+
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
 
         } end
 
@@ -380,7 +422,9 @@ context (test_string) {
                     char* string_empty_array = "[]";
                     char** empty_array = string_get_string_as_array(string_empty_array);
                     should_ptr(empty_array) not be null;
-                    should_ptr(empty_array[0]) be null;
+                    should_string(empty_array[0]) be equal to("");
+
+                    string_iterate_lines(empty_array, (void*) free);
                     free(empty_array);
                 } end
 


### PR DESCRIPTION
Este PR incluye:
Fix del bug de `string_split` (https://github.com/sisoputnfrba/so-commons-library/issues/57) , ahora usa `strsep` en vez de `strtok_r`, lo cual permite que se comporte como se esperaba:

```
//Antes: 
string_split("//path//to/file/","/"); => ["path", "to", "file", NULL]
string_split("", "/") => [NULL] 
//Ahora: 
string_split("//path//to/file/","/"); => ["", "", "path", "", "to", "file", "", NULL]
string_split("","/") => ["", NULL]
```