### PR TITLE
Strings: replace y n_append

### DIFF
--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -47,6 +47,14 @@ void string_append(char** original, char* string_to_add) {
 	strcat(*original, string_to_add);
 }
 
+void string_n_append(char** original, char* string_to_add, int n) {
+	if(strlen(string_to_add) < n) {
+		n = strlen(string_to_add);
+	}
+	*original = realloc(*original, strlen(*original) + n + 1);
+	strncat(*original, string_to_add, n);
+}
+
 char* string_new() {
 	return string_duplicate("");
 }
@@ -208,6 +216,26 @@ char* string_reverse(char* palabra) {
 	}
 
 	return resultado;
+}
+
+char* string_replace(char* text, char* pattern, char* replacement) {
+	char* result = string_new();
+	char* start = text;
+	char* next;
+
+	while((next = strstr(start, pattern)) != NULL && *pattern != '\0') {
+		string_n_append(&result, start, next - start);
+		string_append(&result, replacement);
+
+		start = next + strlen(pattern);
+	}
+	string_append(&result, start);
+
+	if(*pattern == '\0') {
+		string_append(&result, replacement);
+	}
+
+	return result;
 }
 
 bool string_contains(char* text, char *substring) {

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -28,6 +28,7 @@ static void _string_upper_element(char* ch);
 void _string_append_with_format_list(const char* format, char** original, va_list arguments);
 char** _string_split(char* text, char* separator, bool(*is_last_token)(int));
 static void _string_array_push(char*** array, char* text, int size);
+static char* _string_iterate_with_pattern(char* text, char* pattern, bool(*iterator)(char*, char*));
 
 char *string_repeat(char character, int count) {
 	char *text = calloc(count + 1, 1);
@@ -220,20 +221,16 @@ char* string_reverse(char* palabra) {
 
 char* string_replace(char* text, char* pattern, char* replacement) {
 	char *result = string_new();
-	char *start = text;
+	char *last_part;
 
-	if (pattern != NULL) {
-		char *end = strstr(start, pattern) + !string_is_empty(text) * string_is_empty(pattern);
-		while(end != NULL && !string_is_empty(end)) {
-			string_n_append(&result, start, end - start);
-			string_append(&result, replacement);
-
-			start = end + strlen(pattern);
-			end = strstr(start, pattern) + string_is_empty(pattern);
-		}
+	bool _replace_pattern(char* start, char* end) {
+		string_n_append(&result, start, end - start);
+		string_append(&result, replacement);
+		return false;
 	}
-	string_append(&result, start);
+	last_part = _string_iterate_with_pattern(text, pattern, _replace_pattern);
 
+	string_append(&result, last_part);
 	if (pattern != NULL && string_is_empty(pattern)) {
 		string_append(&result, replacement);
 	}
@@ -321,20 +318,19 @@ void _string_append_with_format_list(const char* format, char** original, va_lis
 
 char** _string_split(char* text, char* separator, bool(*is_last_token)(int)) {
 	char **substrings = string_array_new();
-	char *start = text;
+	char *last_token;
 	int index = 0;
 
-	if (separator != NULL) {
-		char* end = strstr(start, separator) + !string_is_empty(text) * string_is_empty(separator);
-
-		while (end != NULL && !string_is_empty(end) && !is_last_token(index)) {
-			_string_array_push(&substrings, string_substring_until(start, end - start), index++);
-			start = end + string_length(separator);
-			end = strstr(start, separator) + string_is_empty(separator);
+	bool _push_substring(char* start, char* end) {
+		if (is_last_token(index)) {
+			return true;
 		}
+		_string_array_push(&substrings, string_substring_until(start, end - start), index++);
+		return false;
 	}
+	last_token = _string_iterate_with_pattern(text, separator, _push_substring);
 
-	_string_array_push(&substrings, string_duplicate(start), index);
+	_string_array_push(&substrings, string_duplicate(last_token), index);
 
 	return substrings;
 }
@@ -343,4 +339,23 @@ static void _string_array_push(char*** array, char* text, int size) {
 	*array = realloc(*array, sizeof(char*) * (size + 2));
 	(*array)[size] = text;
 	(*array)[size + 1] = NULL;
+}
+
+static char* _string_iterate_with_pattern(char* text, char* pattern, bool(*iterator)(char*, char*)) {
+	char* start = text;
+
+	if (pattern != NULL) {
+		char *end = strstr(start, pattern) + !string_is_empty(text) * string_is_empty(pattern);
+
+		while(end != NULL && !string_is_empty(end)) {
+			if (iterator(start, end)) {
+				break;
+			}
+
+			start = end + strlen(pattern);
+			end = strstr(start, pattern) + string_is_empty(pattern);
+		}
+	}
+
+	return start;
 }

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -223,6 +223,10 @@ char* string_replace(char* text, char* pattern, char* replacement) {
 	char *result = string_new();
 	char *last_part;
 
+	if (pattern != NULL && string_is_empty(pattern) && !string_is_empty(text)) {
+		string_append(&result, replacement);
+	}
+
 	bool _replace_pattern(char* start, char* end) {
 		string_n_append(&result, start, end - start);
 		string_append(&result, replacement);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -219,19 +219,22 @@ char* string_reverse(char* palabra) {
 }
 
 char* string_replace(char* text, char* pattern, char* replacement) {
-	char* result = string_new();
-	char* start = text;
-	char* next;
+	char *result = string_new();
+	char *start = text;
 
-	while((next = strstr(start, pattern)) != NULL && *pattern != '\0') {
-		string_n_append(&result, start, next - start);
-		string_append(&result, replacement);
+	if (pattern != NULL) {
+		char *end = strstr(start, pattern) + !string_is_empty(text) * string_is_empty(pattern);
+		while(end != NULL && !string_is_empty(end)) {
+			string_n_append(&result, start, end - start);
+			string_append(&result, replacement);
 
-		start = next + strlen(pattern);
+			start = end + strlen(pattern);
+			end = strstr(start, pattern) + string_is_empty(pattern);
+		}
 	}
 	string_append(&result, start);
 
-	if(*pattern == '\0') {
+	if (pattern != NULL && string_is_empty(pattern)) {
 		string_append(&result, replacement);
 	}
 
@@ -318,19 +321,16 @@ void _string_append_with_format_list(const char* format, char** original, va_lis
 
 char** _string_split(char* text, char* separator, bool(*is_last_token)(int)) {
 	char **substrings = string_array_new();
+	char *start = text;
 	int index = 0;
 
-	char *end, *start = text;
 	if (separator != NULL) {
-		while ((end = strstr(start, separator)) != NULL && !is_last_token(index)) {
-			if (string_is_empty(separator)) {
-				if (string_length(start) > 1)
-					end = start + 1;
-			 	else
-					break;
-			}
+		char* end = strstr(start, separator) + !string_is_empty(text) * string_is_empty(separator);
+
+		while (end != NULL && !string_is_empty(end) && !is_last_token(index)) {
 			_string_array_push(&substrings, string_substring_until(start, end - start), index++);
 			start = end + string_length(separator);
+			end = strstr(start, separator) + string_is_empty(separator);
 		}
 	}
 

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -259,15 +259,15 @@
 	/**
 	* @NAME: string_replace
 	* @DESC: Retorna una copia de un string con todas las ocurrencias
-	* de 'pattern' siendo reemplazadas por 'replacement'.
+	* de un substring no vacío siendo reemplazadas por otro string.
 	*
 	* Ejemplo:
 	* char* original = "hello";
-	* string_replace(original, "o", "o world!") => "hello world!"
-	* string_replace(original, "", "x"); => "xhxexlxlxox"
-	* string_replace(original, NULL, "x"); => "hello"
+	* string_replace(original, "ello", "ola") => "hola"
+	* string_replace(original, "l", ""); => "heo"
+	* string_replace(original, "not a substring", "yay!"); => "hello"
 	*/
-	char*   string_replace(char* text, char* pattern, char* replacement);
+	char*   string_replace(char* text, char* substring, char* replacement);
 
 	/**
 	 * @NAME: string_contains

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -74,6 +74,20 @@
 	void    string_append(char ** original, char * string_to_add);
 
 	/**
+	* @NAME: string_n_append
+	* @DESC: Agrega al primer string un máximo de n caracteres
+	* del segundo.
+	*
+	* Ejemplo:
+	* char *unaPalabra = string_new();
+	* string_n_append(&unaPalabra, "HOLA ", 10);
+	* string_n_append(&unaPalabra, "PEPE", 3);
+	*
+	* => unaPalabra = "HOLA PEP"
+	*/
+	void    string_n_append(char** original, char* string_to_add, int n);
+
+	/**
 	* @NAME: string_append_with_format
 	* @DESC: Concatena al primer string el resultado de aplicar los parametros al
 	* formato especificado
@@ -241,6 +255,20 @@
 	 * string_reverse(original) => "oob"
 	 */
 	char*   string_reverse(char* text);
+
+	/**
+	* @NAME: string_replace
+	* @DESC: Retorna una copia de un string con todas las ocurrencias
+	* de 'pattern' siendo reemplazadas por 'replacement'. En caso de
+	* recibir un string vacío como 'pattern', concatena 'replacement'
+	* al final de 'text'.
+	*
+	* Ejemplo:
+	* char* original = "hello";
+	* string_replace(original, "o", "o world!") => "hello world!"
+	* string_replace(original, "", "!") => "hello!"
+	*/
+	char*   string_replace(char* text, char* pattern, char* replacement);
 
 	/**
 	 * @NAME: string_contains

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -259,14 +259,13 @@
 	/**
 	* @NAME: string_replace
 	* @DESC: Retorna una copia de un string con todas las ocurrencias
-	* de 'pattern' siendo reemplazadas por 'replacement'. En caso de
-	* recibir un string vacío como 'pattern', concatena 'replacement'
-	* al final de 'text'.
+	* de 'pattern' siendo reemplazadas por 'replacement'.
 	*
 	* Ejemplo:
 	* char* original = "hello";
 	* string_replace(original, "o", "o world!") => "hello world!"
-	* string_replace(original, "", "!") => "hello!"
+	* string_replace(original, "", "x"); => "xhxexlxlxox"
+	* string_replace(original, NULL, "x"); => "hello"
 	*/
 	char*   string_replace(char* text, char* pattern, char* replacement);
 

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -553,7 +553,7 @@ context (test_string) {
 
             it ("replace the end when empty string is the pattern") {
                 replaced = string_replace("hello", "", "x");
-                should_string(replaced) be equal to ("hxexlxlxox");
+                should_string(replaced) be equal to ("xhxexlxlxox");
             } end
 
             it ("replace the end when empty string is text and pattern") {

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -519,7 +519,7 @@ context (test_string) {
             } end
         } end
 
-        describe("Replace") {
+        describe("Replacing") {
             char* replaced;
 
             after {
@@ -552,10 +552,19 @@ context (test_string) {
             } end
 
             it ("replace the end when empty string is the pattern") {
-                replaced = string_replace("hello", "", "!");
-                should_string(replaced) be equal to ("hello!");
+                replaced = string_replace("hello", "", "x");
+                should_string(replaced) be equal to ("hxexlxlxox");
             } end
 
+            it ("replace the end when empty string is text and pattern") {
+                replaced = string_replace("", "", "x");
+                should_string(replaced) be equal to ("x");
+            } end
+
+            it ("replace with null pattern duplicates original text") {
+                replaced = string_replace("hello", NULL, "error");
+                should_string(replaced) be equal to ("hello");
+            } end
         } end
 
         it("Contains") {

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -50,6 +50,17 @@ context (test_string) {
             free(string);
         } end
 
+        it("n_append") {
+            char *string = string_new();
+            string_n_append(&string, "Hello", 10);
+            string_n_append(&string, "     ", 1);
+            string_n_append(&string, "world", 5);
+
+            should_string(string) be equal to("Hello world");
+
+            free(string);
+        } end
+
         it("append_with_format") {
             char *string = string_new();
 
@@ -506,6 +517,45 @@ context (test_string) {
                 should_string(reverse_word) be equal to("");
                 free(reverse_word);
             } end
+        } end
+
+        describe("Replace") {
+            char* replaced;
+
+            after {
+                free(replaced);
+            } end
+
+            it ("replace multiple occurrences") {
+                replaced = string_replace("hexxo worxd!", "x", "l");
+                should_string(replaced) be equal to ("hello world!");
+            } end
+
+            it ("replace an occurrence with a longer one") {
+                replaced = string_replace("hello", "o", "o world!");
+                should_string(replaced) be equal to ("hello world!");
+            } end
+
+            it ("replace an occurrence with a shorter one") {
+                replaced = string_replace("hello", "ello", "ola");
+                should_string(replaced) be equal to ("hola");
+            } end
+
+            it ("replace every occurrence with empty string") {
+                replaced = string_replace("hello", "l", "");
+                should_string(replaced) be equal to ("heo");
+            } end
+
+            it ("replace duplicates original when doesn't receive a substring as pattern") {
+                replaced = string_replace("hello", "definitely not a substring", "test failed!");
+                should_string(replaced) be equal to ("hello");
+            } end
+
+            it ("replace the end when empty string is the pattern") {
+                replaced = string_replace("hello", "", "!");
+                should_string(replaced) be equal to ("hello!");
+            } end
+
         } end
 
         it("Contains") {

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -550,21 +550,6 @@ context (test_string) {
                 replaced = string_replace("hello", "definitely not a substring", "test failed!");
                 should_string(replaced) be equal to ("hello");
             } end
-
-            it ("replace the end when empty string is the pattern") {
-                replaced = string_replace("hello", "", "x");
-                should_string(replaced) be equal to ("xhxexlxlxox");
-            } end
-
-            it ("replace the end when empty string is text and pattern") {
-                replaced = string_replace("", "", "x");
-                should_string(replaced) be equal to ("x");
-            } end
-
-            it ("replace with null pattern duplicates original text") {
-                replaced = string_replace("hello", NULL, "error");
-                should_string(replaced) be equal to ("hello");
-            } end
         } end
 
         it("Contains") {


### PR DESCRIPTION
Este PR incluye:

1. Función `string_replace` (https://github.com/sisoputnfrba/so-commons-library/issues/59). Devuelve:

```C
string_replace("hello", "ello", "ola"); // => "hola"
string_replace("hello", "l", ""); //  => "heo"
string_replace("hello", "o", "o world!"); //  => "hello world!"
string_replace("hello", "not a substring", "yay!"); //  => "hello"
```

Los otros casos los dejé como comportamiento no definido por si lo llegamos a cambiar para que coincida con [`String.prototype.replaceAll()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll), pero devuelven:
```C
string_replace("hello", "", "x"); //  => "hxexlxlxo"
string_replace("hello", NULL, "x"); //  => "hello"
string_replace(NULL, "a", "x") // => error
```

https://github.com/sisoputnfrba/so-commons-library/blob/43dcbb1ae54dd5a4d4f7e5346da945d79ff80e16/src/commons/string.h#L259-L270

2. Función `string_n_append` (que me sirvió para `string_replace`):

https://github.com/sisoputnfrba/so-commons-library/blob/43dcbb1ae54dd5a4d4f7e5346da945d79ff80e16/src/commons/string.h#L77-L88
