### PR TITLE
Listas: Remove element from pointer

### DIFF
--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -124,7 +124,7 @@ void *list_remove(t_list *self, int index) {
 	return data;
 }
 
-void list_remove_element(t_list* self, void* item) {
+bool list_remove_element(t_list* self, void* item) {
 	t_link_element *element = NULL;
 
 	bool _remove_item(t_link_element* element, int i) {
@@ -135,6 +135,8 @@ void list_remove_element(t_list* self, void* item) {
 	if(element != NULL) {
 		free(element);
 	}
+
+	return !!element;
 }
 
 void* list_remove_by_condition(t_list *self, bool(*condition)(void*)) {

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -163,9 +163,10 @@
 
 	/**
 	* @NAME: list_remove_element
-	* @DESC: Remueve al elemento de la lista recibido por parámetro.
+	* @DESC: Remueve al elemento de la lista recibido por parámetro. Retorna true
+	* si el elemento fue removido correctamente y false si no se encontró
 	*/
-	void list_remove_element(t_list* self, void* element);
+	bool list_remove_element(t_list* self, void* element);
 
 	/**
 	* @NAME: list_remove_and_destroy_element

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -70,7 +70,7 @@
 	* El comparador devuelve si el primer parametro debe aparecer antes que el
 	* segundo en la lista
 	*/
-	int list_add_sorted(t_list *self, void* data, bool (*comparator)(void*,void*));
+	int list_add_sorted(t_list *self, void* element, bool (*comparator)(void*,void*));
 
 	/**
 	* @NAME: list_add_all
@@ -160,6 +160,12 @@
 	* una determinada posicion y lo retorna.
 	*/
 	void *list_remove(t_list *, int index);
+
+	/**
+	* @NAME: list_remove_element
+	* @DESC: Remueve al elemento de la lista recibido por parámetro.
+	*/
+	void list_remove_element(t_list* self, void* element);
 
 	/**
 	* @NAME: list_remove_and_destroy_element

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -194,6 +194,18 @@ context (test_list) {
                 should_int(list_size(list)) be equal to(4);
             } end
 
+            it("should remove a value from its pointer") {
+                should_int(list_size(list)) be equal to(5);
+
+                t_person* aux = list_get(list, 1);
+                list_remove_element(list, aux);
+                persona_destroy(aux);
+
+                assert_person_in_list(list, 1, "Sebastian", 21);
+                should_int(list_size(list)) be equal to(4);
+
+            } end
+
             it("should remove and destroy a value at index") {
                 assert_person_in_list(list, 0, "Matias", 24);
                 should_int(list_size(list)) be equal to(5);

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -198,12 +198,20 @@ context (test_list) {
                 should_int(list_size(list)) be equal to(5);
 
                 t_person* aux = list_get(list, 1);
-                list_remove_element(list, aux);
+                should_bool(list_remove_element(list, aux)) be truthy;
                 persona_destroy(aux);
 
                 assert_person_in_list(list, 1, "Sebastian", 21);
                 should_int(list_size(list)) be equal to(4);
 
+            } end
+
+            it("shouldn't remove a value that doesn't belong to the list") {
+                should_int(list_size(list)) be equal to(5);
+
+                should_bool(list_remove_element(list, NULL)) be falsey;
+
+                should_int(list_size(list)) be equal to(5);
             } end
 
             it("should remove and destroy a value at index") {


### PR DESCRIPTION
La sugerí en (#34), básicamente en vez de *guardarme el índice para en otro momento hacer un remove de ese elemento en la lista*, directamente me quedo con el puntero y cuando quiera quitarlo uso esta función.

```c
	/**
	* @NAME: list_remove_element
	* @DESC: Remueve al elemento de la lista recibido por parámetro. Retorna true
	* si el elemento fue removido correctamente y false si no se encontró
	*/
	bool list_remove_element(t_list* self, void* element);
```
Esto es incluso es algo más seguro que guardar un índice, te previene de que la lista sea modificada y que el elemento que quieras mover no esté ahí. Sé que se puede hacer un `remove_by_condition` que le pase una inner function que compare ambos punteros, pero exponer esta opción puede ser más expresivo (aunque, en realidad, hace lo mismo).

También tuve que renombrar una función privada que tenía el mismo nombre (y un par más para que quede coherente xd), por eso hay más cambios.