### PR TITLE
Makefiles para evitar rebuilds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler: gcc
 before_install:
         - sudo apt-get install -y valgrind
         - cd tests/unit-tests/
-install: make install-cspec
+install: make ../../cspec/release/libcspecs.so
 
 script: make valgrind
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Instrucciones de instalación:
 
 - Clonar el repositorio desde git (no usar el link de **Download ZIP** que provee GitHub).
 
-- `sudo make install` -> instala la biblioteca en el sistema
+- `make install` -> instala la biblioteca en el sistema
 
-- `sudo make uninstall` -> desinstala la biblioteca
+- `make uninstall` -> desinstala la biblioteca
 
 [![asciicast](https://asciinema.org/a/17x56e36koqybtq1jx8p3kfnp.png)](https://asciinema.org/a/17x56e36koqybtq1jx8p3kfnp)
 

--- a/makefile
+++ b/makefile
@@ -19,5 +19,5 @@ install: test
 uninstall:
 	-cd src && $(MAKE) uninstall
 
-valgrind: all
+valgrind: debug
 	-cd tests/unit-tests && $(MAKE) valgrind

--- a/src/makefile
+++ b/src/makefile
@@ -8,21 +8,22 @@ OBJS=$(C_SRCS:./%.c=build/%.o)
 # Clean and compile .so
 all: build/libcommons.so
 
-create-dirs:
-	mkdir -p build/commons/collections
+build/commons/collections:
+	mkdir -p $@
 
-build/libcommons.so: create-dirs $(OBJS)
-	$(CC) -shared -o "build/libcommons.so" $(OBJS)
+build/libcommons.so: build/commons/collections $(OBJS)
+	$(CC) -shared -o "$@" $(OBJS)
 
-build/commons/%.o: commons/%.c
-	$(CC) -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
-
-build/commons/collections/%.o: commons/collections/%.c
+build/%.o: %.c
 	$(CC) -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 
 # Add debug parameters and compile
 debug: CC += -DDEBUG -g
 debug: all
+
+# Print all sources
+sources:
+	@echo $(C_SRCS) $(H_SRCS)
 
 # Clean build files
 clean:
@@ -36,4 +37,4 @@ uninstall:
 	rm -f /usr/lib/libcommons.so
 	rm -rf /usr/include/commons
 
-.PHONY: all create-dirs clean install uninstall
+.PHONY: all debug sources clean install uninstall

--- a/src/makefile
+++ b/src/makefile
@@ -30,11 +30,11 @@ clean:
 	$(RM) build
 
 install: all
-	cp -u build/libcommons.so /usr/lib
-	cp --parents -u $(H_SRCS) /usr/include
+	sudo cp -u build/libcommons.so /usr/lib
+	sudo cp --parents -u $(H_SRCS) /usr/include
 
 uninstall:
-	rm -f /usr/lib/libcommons.so
-	rm -rf /usr/include/commons
+	sudo rm -f /usr/lib/libcommons.so
+	sudo rm -rf /usr/include/commons
 
 .PHONY: all debug sources clean install uninstall

--- a/tests/unit-tests/makefile
+++ b/tests/unit-tests/makefile
@@ -1,22 +1,33 @@
 RM=rm -rf
 CC=gcc
 
-C_SPEC=../../cspec
+BASE_DIR=../..
+
+C_SPEC=$(BASE_DIR)/cspec
 C_SPEC_BIN=$(C_SPEC)/release
+C_SPEC_SO=$(C_SPEC_BIN)/libcspecs.so
+
+COMMONS=$(BASE_DIR)/src
+COMMONS_BIN=$(COMMONS)/build
+COMMONS_SO=$(COMMONS_BIN)/libcommons.so
+COMMONS_SRCS=$(patsubst ./%,$(COMMONS)/%,$(shell make --no-print-directory -C $(COMMONS) sources)) 
 
 C_SRCS=$(shell find . -iname "*.c" | tr '\n' ' ')
 OBJS=$(C_SRCS:./%.c=build/%.o)
 
-all: build/commons-unit-test
+BIN_DIR=build
+BIN=$(BIN_DIR)/commons-unit-test
 
-create-dirs:
-	mkdir -p build
+all: $(BIN)
 
-build/commons-unit-test: dependents create-dirs $(OBJS)
-	$(CC) -L"../../src/build" -L"$(C_SPEC_BIN)" -o "build/commons-unit-test" $(OBJS) -lcommons -lcspecs
+$(BIN_DIR):
+	mkdir -p $@
+
+$(BIN): $(C_SPEC_SO) $(COMMONS_SO) $(BIN_DIR) $(OBJS)
+	$(CC) -L"$(COMMONS_BIN)" -L"$(C_SPEC_BIN)" -o "$@" $(OBJS) -lcommons -lcspecs
 
 build/%.o: ./%.c
-	$(CC) -I"../../src" -I"$(C_SPEC)" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	$(CC) -I"$(COMMONS)" -I"$(C_SPEC)" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 
 debug: CC += -DDEBUG -g
 debug: all
@@ -25,16 +36,16 @@ clean:
 	$(RM) build
 
 test: all
-	LD_LIBRARY_PATH="../../src/build/:$(C_SPEC_BIN)" build/commons-unit-test
+	LD_LIBRARY_PATH="$(COMMONS_BIN):$(C_SPEC_BIN)" ./$(BIN)
 
-dependents: install-cspec
-	-cd ../../src/ && $(MAKE) all
+$(COMMONS_SO): $(COMMONS_SRCS)
+	-cd $(COMMONS) && $(MAKE) all
 
-install-cspec:
-	-cd ../../ && git submodule init && git submodule update
-	-cd ../../cspec && $(MAKE) all
+$(C_SPEC_SO):
+	-cd $(BASE_DIR) && git submodule init && git submodule update
+	-cd $(C_SPEC) && $(MAKE) all
 
-valgrind: all
-	LD_LIBRARY_PATH="../../src/build/:$(C_SPEC_BIN)" valgrind --error-exitcode=42 --leak-check=full -v ./build/commons-unit-test
+valgrind: debug
+	LD_LIBRARY_PATH="$(COMMONS_BIN)/:$(C_SPEC_BIN)" valgrind --error-exitcode=42 --leak-check=full -v ./$(BIN)
 
-.PHONY: all create-dirs clean install-cspec valgrind
+.PHONY: all debug clean test valgrind


### PR DESCRIPTION
Al codear para los otros PRs, incluí reglas para evitar rebuilds y para que los unit-tests no hagan "nothing to be done for all" cuando solo fixee algo de los srcs xd
También, de paso, vi que ahora estamos haciendo `make && sudo make install` para instalar cuando en realidad se puede incluir el sudo solo al copiar los archivos a `/usr`, de esa forma se evita tener problemas con los permisos al hacer solo `make install`.