### PR TITLE
String: Usar delimitadores de más de un caracter en split

### DIFF
--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -293,7 +293,7 @@ char** _string_split(char* text, char* separator, bool(*is_last_token)(int)) {
 	char *start = text, *next;
 	while (separator != NULL && !is_last_token(index) && (next = strstr(start, separator))) {
 		if (strlen(separator) == 0) {
-			if (strlen(start) == 1) {
+			if (strlen(start) <= 1) {
 				break;
 			}
 			next++;

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -288,25 +288,23 @@ void _string_append_with_format_list(const char* format, char** original, va_lis
 
 char** _string_split(char* text, char* separator, bool(*condition)(char*, int)) {
 	char **substrings = string_array_new();
-	int size = 0;
+	int size = 0, separator_length = strlen(separator);
 
-	char *text_to_iterate = string_duplicate(text);
-	char *next = text_to_iterate;
-
+	char* start = text;
+	char* next = strstr(start, separator);
 	while(condition(next, size)) {
-		char* token = strsep(&next, separator);
-		if(token == NULL) {
-			break;
-		}
-		_string_array_push(&substrings, string_duplicate(token), size);
 		size++;
+		substrings = realloc(substrings, sizeof(char*) * size);
+		substrings[size - 1] = string_substring_until(start, next - start);
+		start = next + separator_length;
+		next = strstr(start, separator);
 	};
 
-	if (next != NULL) {
-		_string_array_push(&substrings, string_duplicate(next), size);
-	}
+	size += 2;
+	substrings = realloc(substrings, sizeof(char*) * size);
+	substrings[size - 2] = string_duplicate(start);
+	substrings[size - 1] = NULL;
 
-	free(text_to_iterate);
 	return substrings;
 }
 

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -288,19 +288,24 @@ void _string_append_with_format_list(const char* format, char** original, va_lis
 
 char** _string_split(char* text, char* separator, bool(*condition)(char*, char*, int)) {
 	char **substrings = NULL;
-	int size = 0, separator_length = strlen(separator);
+	int size = 0;
 
 	char* start = text;
-	char* next = separator_length ? strstr(start, separator) : start + 1;
-	while(condition(start, next, size)) {
-		size++;
-		substrings = realloc(substrings, sizeof(char*) * size);
-		substrings[size - 1] = string_substring_until(start, next - start);
-		start = next + separator_length;
-		next = separator_length ? strstr(start, separator) : start + 1;
+	if(separator != NULL) {
+		int separator_length = strlen(separator);
+		do {
+			char* next = separator_length ? strstr(start, separator) : start + 1;
+			if(!condition(start, next, size)) {
+				break;
+			}
+			size++;
+			substrings = realloc(substrings, sizeof(char*) * size);
+			substrings[size - 1] = string_substring_until(start, next - start);
+			start = next + separator_length;
+		} while(true);
 	}
 
-	if(separator_length > 0) {
+	if(separator == NULL || separator[0] != '\0') {
 		size++;
 		substrings = realloc(substrings, sizeof(char*) * size);
 		substrings[size - 1] = string_duplicate(start);

--- a/src/commons/string.c
+++ b/src/commons/string.c
@@ -290,17 +290,18 @@ char** _string_split(char* text, char* separator, bool(*is_last_token)(int)) {
 	char **substrings = string_array_new();
 	int index = 0;
 
-	char *start = text, *next;
-	while (separator != NULL && !is_last_token(index) && (next = strstr(start, separator))) {
-		if (strlen(separator) == 0) {
-			if (strlen(start) <= 1) {
-				break;
+	char *end, *start = text;
+	if (separator != NULL) {
+		while ((end = strstr(start, separator)) != NULL && !is_last_token(index)) {
+			if (string_is_empty(separator)) {
+				if (string_length(start) > 1)
+					end = start + 1;
+			 	else
+					break;
 			}
-			next++;
+			_string_array_push(&substrings, string_substring_until(start, end - start), index++);
+			start = end + string_length(separator);
 		}
-		_string_array_push(&substrings, string_substring_until(start, next - start), index);
-		start = next + strlen(separator);
-		index++;
 	}
 
 	_string_array_push(&substrings, string_duplicate(start), index);

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -195,6 +195,22 @@ context (test_string) {
                 string_array_destroy(substrings);
             } end
 
+            it("split_with_empty_string") {
+                char *line = "hello";
+                char** substrings = string_split(line, "");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("h");
+                should_string(substrings[1]) be equal to ("e");
+                should_string(substrings[2]) be equal to ("l");
+                should_string(substrings[3]) be equal to ("l");
+                should_string(substrings[4]) be equal to ("o");
+                should_ptr(substrings[5]) be null;
+
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
+
             it("split_starting_with_delimitator") {
                 char* line = "/path/to/file";
                 char** substrings = string_split(line, "/");

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -182,7 +182,7 @@ context (test_string) {
 
         describe("Split") {
 
-            it("split_with_delimitators") {
+            it("split_with_separators") {
                 char *line = "path//to//file";
                 char** substrings = string_split(line, "//");
 
@@ -195,7 +195,7 @@ context (test_string) {
                 string_array_destroy(substrings);
             } end
 
-            it("split_with_empty_string") {
+            it("split_with_empty_string_as_separator") {
                 char *line = "hello";
                 char** substrings = string_split(line, "");
 
@@ -211,7 +211,19 @@ context (test_string) {
                 free(substrings);
             } end
 
-            it("split_starting_with_delimitator") {
+            it("split_with_null_separator") {
+                char *line = "path/to/file";
+                char** substrings = string_split(line, NULL);
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to ("path/to/file");
+                should_ptr(substrings[1]) be null;
+
+                string_iterate_lines(substrings, (void*) free);
+                free(substrings);
+            } end
+
+            it("split_starting_with_separator") {
                 char* line = "/path/to/file";
                 char** substrings = string_split(line, "/");
 
@@ -225,7 +237,7 @@ context (test_string) {
                 string_array_destroy(substrings);
             } end
 
-            it("split_ending_with_delimitator") {
+            it("split_ending_with_separator") {
                 char* line = "path/to/file/";
                 char** substrings = string_split(line, "/");
 
@@ -239,7 +251,7 @@ context (test_string) {
                 string_array_destroy(substrings);
             } end
 
-            it("split_having_delimitators_in_between") {
+            it("split_having_separators_in_between") {
                 char* line = "path/to//file";
                 char** substrings = string_split(line, "/");
 

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -277,6 +277,18 @@ context (test_string) {
 
             } end
 
+            it("split_is_empty_with_empty_separator") {
+                char* line = "";
+                char** substrings = string_split(line, "");
+
+                should_ptr(substrings) not be null;
+                should_string(substrings[0]) be equal to("");
+                should_ptr(substrings[1]) be null;
+
+                string_array_destroy(substrings);
+
+            } end
+
             it("n_split_when_n_is_less_than_splitted_elements") {
                 char *line = "Hola planeta tierra";
                 char** substrings = string_n_split(line, 2, " ");

--- a/tests/unit-tests/test_string.c
+++ b/tests/unit-tests/test_string.c
@@ -183,8 +183,8 @@ context (test_string) {
         describe("Split") {
 
             it("split_with_delimitators") {
-                char *line = "path/to/file";
-                char** substrings = string_split(line, "/");
+                char *line = "path//to//file";
+                char** substrings = string_split(line, "//");
 
                 should_ptr(substrings) not be null;
                 should_string(substrings[0]) be equal to ("path");


### PR DESCRIPTION
Resuelve #141 

Ahora tiene un comportamiento 100% igual a [split en JS](https://www.w3schools.com/jsref/jsref_split.asp#:~:text=The%20split()%20method%20is,not%20change%20the%20original%20string.):
- El delimitador es un string (en vez de ser todos los caracteres que lo componen)
- Si el delimitador es string vacío, hace un array de strings con cada caracter
- Si el delimitador es nulo, devuelve un array cuyo primer valor es el string completo