### PR TITLE
Dictionary: Parse

### DIFF
--- a/src/commons/collections/dictionary.c
+++ b/src/commons/collections/dictionary.c
@@ -23,6 +23,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "../string.h"
 #include "dictionary.h"
 
 static unsigned int dictionary_hash(char *key, int key_len);
@@ -40,6 +41,23 @@ t_dictionary *dictionary_create() {
 	self->elements = calloc(self->table_max_size, sizeof(t_hash_element*));
 	self->table_current_size = 0;
 	self->elements_amount = 0;
+	return self;
+}
+
+t_dictionary* dictionary_parse(char* buffer, void* (*data_parser)(char*)) {
+	t_dictionary* self = dictionary_create();
+	char** lines = string_split(buffer, "\n");
+
+	void add_cofiguration(char *line) {
+		if (!string_is_empty(line) && !string_starts_with(line, "#")) {
+			char** keyAndValue = string_n_split(line, 2, "=");
+			dictionary_put(self, keyAndValue[0], data_parser(keyAndValue[1]));
+			string_array_destroy(keyAndValue);
+		}
+	}
+	string_iterate_lines(lines, add_cofiguration);
+	string_array_destroy(lines);
+
 	return self;
 }
 

--- a/src/commons/collections/dictionary.h
+++ b/src/commons/collections/dictionary.h
@@ -36,6 +36,18 @@
 	t_dictionary *dictionary_create();
 
 	/**
+	* @NAME: dictionary_parse
+	* @DESC: Crea un diccionario en base a un string con formato: 
+	* "key1=data1\nkey2=data2\n...\nkeyN=dataN".
+	* [Warning] - Las líneas vacías ("\n\n") y las que empiezan con el caracter '#' son ignoradas.
+	* 
+	* La función que se pasa por parámetro devuelve un puntero hacia el elemento parseado a partir del 
+	* string recibido.
+	* [Warning] - La memoria ocupada por parámetro que recibe `data_parser` es posteriormente liberada.
+	*/
+	t_dictionary *dictionary_parse(char* buffer, void* (*data_parser)(char*));
+
+	/**
 	* @NAME: dictionary_put
 	* @DESC: Inserta un nuevo par (key->data) al diccionario, en caso de ya existir la key actualiza la data.
 	* [Warning] - Tener en cuenta que esto no va a liberar la memoria del `data` original.

--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -36,7 +36,6 @@ t_config *config_create(char *path) {
 	t_config *config = malloc(sizeof(t_config));
 
 	config->path = strdup(path);
-	config->properties = dictionary_create();
 
 	char* buffer = calloc(1, stat_file.st_size + 1);
 	fread(buffer, stat_file.st_size, 1, file);
@@ -48,19 +47,8 @@ t_config *config_create(char *path) {
 		 "and use `dos2unix` program to convert your files to Unix style.\n\n", path);
 	}
 
-	char** lines = string_split(buffer, "\n");
+	config->properties = dictionary_parse(buffer, (void*) string_duplicate);
 
-	void add_cofiguration(char *line) {
-		if (!string_is_empty(line) && !string_starts_with(line, "#")) {
-			char** keyAndValue = string_n_split(line, 2, "=");
-			dictionary_put(config->properties, keyAndValue[0], keyAndValue[1]);
-			free(keyAndValue[0]);
-			free(keyAndValue);
-		}
-	}
-	string_iterate_lines(lines, add_cofiguration);
-
-	string_array_destroy(lines);
 	free(buffer);
 	fclose(file);
 
@@ -129,7 +117,7 @@ int config_save_in_file(t_config *self, char* path) {
 	FILE* file = fopen(path, "wb+");
 
 	if (file == NULL) {
-			return -1;
+		return -1;
 	}
 
 	char* lines = string_new();


### PR DESCRIPTION
Nos sirvió mucho en su día contar con una función que parseara un string en "formato config", ya que lo armábamos a partir de concatenar todos los bloques de un archivo, así que creo que sería útil tenerlo al igual que en JS contamos con un `JSON.parse()`.

Me falta armar los tests unitarios, aunque estaría como "testeado" ya que se usa para parsear los archivos config.