### PR TITLE
Agregar attributes a funciones printf-like

### DIFF
--- a/src/commons/log.h
+++ b/src/commons/log.h
@@ -58,7 +58,7 @@
 	* [TRACE] hh:mm:ss:mmmm PROCESS_NAME/(PID:TID): MESSAGE
 	*
 	*/
-	void 		log_trace(t_log* logger, const char* message, ...);
+	void 		log_trace(t_log* logger, const char* message, ...) __attribute__((format(printf, 2, 3)));
 
 	/**
 	* @NAME: log_debug
@@ -67,7 +67,7 @@
 	* [DEBUG] hh:mm:ss:mmmm PROCESS_NAME/(PID:TID): MESSAGE
 	*
 	*/
-	void 		log_debug(t_log* logger, const char* message, ...);
+	void 		log_debug(t_log* logger, const char* message, ...) __attribute__((format(printf, 2, 3)));
 
 	/**
 	* @NAME: log_info
@@ -76,7 +76,7 @@
 	* [INFO] hh:mm:ss:mmmm PROCESS_NAME/(PID:TID): MESSAGE
 	*
 	*/
-	void 		log_info(t_log* logger, const char* message, ...);
+	void 		log_info(t_log* logger, const char* message, ...) __attribute__((format(printf, 2, 3)));
 
 	/**
 	* @NAME: log_warning
@@ -85,7 +85,7 @@
 	* [WARNING] hh:mm:ss:mmmm PROCESS_NAME/(PID:TID): MESSAGE
 	*
 	*/
-	void 		log_warning(t_log* logger, const char* message, ...);
+	void 		log_warning(t_log* logger, const char* message, ...) __attribute__((format(printf, 2, 3)));
 
 	/**
 	* @NAME: log_error
@@ -94,7 +94,7 @@
 	* [ERROR] hh:mm:ss:mmmm PROCESS_NAME/(PID:TID): MESSAGE
 	*
 	*/
-	void 		log_error(t_log* logger, const char* message, ...);
+	void 		log_error(t_log* logger, const char* message, ...) __attribute__((format(printf, 2, 3)));
 
 	/**
 	* @NAME: log_level_as_string

--- a/src/commons/string.h
+++ b/src/commons/string.h
@@ -41,7 +41,7 @@
 	*
 	* => saludo = "Hola mundo"
 	*/
-	char*   string_from_format(const char* format, ...);
+	char*   string_from_format(const char* format, ...) __attribute__((format(printf, 1, 2)));
 
 	/**
 	* @NAME: string_from_vformat
@@ -86,7 +86,7 @@
 	*
 	* => saludo = "HOLA PEPE!"
 	*/
-	void    string_append_with_format(char **original, const char *format, ...);
+	void    string_append_with_format(char **original, const char *format, ...) __attribute__((format(printf, 2, 3)));
 
 	/**
 	* @NAME: string_duplicate


### PR DESCRIPTION
De la nada me encontré con que [este atributo](https://www.keil.com/support/man/docs/armcc/armcc_sam1436458756975.htm) es el que hace que el compilador nos chille cuando la estemos pifiando con `printf(...)`. Al mergear este PR, va a pasar lo mismo en cualquier función de log 🎉 
```c
#include <commons/log.h>

int main() {
    t_log* logger = log_create("yo-tengo-tu.log", "I_GOT_YOUR_LOG", 1, 0);
    log_info(logger, "%s");
    return 0;
}
```

```
$ gcc -g -o main main.c -lcommons
main.c: In function ‘main’:
main.c:5:21: warning: format ‘%s’ expects a matching ‘char *’ argument [-Wformat=]
    5 |     log_info(logger, "%s");
      |                    ~^
      |                     |
      |                     char *
```
