### PR TITLE
Warnings de formato (-Wformat)

### DIFF
--- a/src/commons/config.c
+++ b/src/commons/config.c
@@ -134,7 +134,7 @@ int config_save_in_file(t_config *self, char* path) {
 
 	char* lines = string_new();
 	void add_line(char* key, void* value) {
-		string_append_with_format(&lines, "%s=%s\n", key, value);
+		string_append_with_format(&lines, "%s=%s\n", key, (char *) value);
 	}
 
 	dictionary_iterator(self->properties, add_line);

--- a/src/commons/temporal.c
+++ b/src/commons/temporal.c
@@ -32,7 +32,7 @@ char *temporal_get_string_time(const char* format) {
 	if(clock_gettime(CLOCK_REALTIME, log_timespec) == -1) {
 		return NULL;
 	}
-	milisec = string_from_format("%03d", log_timespec->tv_nsec / 1000000);
+	milisec = string_from_format("%03ld", log_timespec->tv_nsec / 1000000);
 
 	for(char* ms = strstr(str_time, "%MS"); ms != NULL; ms = strstr(ms + 3, "%MS")) {
 		memcpy(ms, milisec, 3);


### PR DESCRIPTION
## Formato

Cuando installé las commons me salía:

```
commons/config.c:137:56: warning: format ‘%s’ expects argument of type ‘char *’, but argument 4 has type ‘void *’ [-Wformat=]
  137 |                 string_append_with_format(&lines, "%s=%s\n", key, value);
      |                                                       ~^          ~~~~~
      |                                                        |          |
      |                                                        char *     void *
      |                                                       %p
```

Agregué el cast a `char *`, qué es lo que enrealdiad espera.

A su vez, al forkear el repo también salto otra `warning` en `temporal.c`, en este caso esperaba `int` pero el argumento era `long int`. Cambié de `%d` a `%ld` que sería _format specifier_ correcto.

**No altera ninguna funcionalidad**. Sólo corrige las warnings.
