### PR TITLE
Build: Actualizo Docker image al nuevo entorno

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!src
+!tests
+!makefile
+
+**/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y aptitude gcc gdb git vim libncurses5 valgrind tig make autotools-dev strace emacs nano libcunit1 libevent1-dev ssh libfuse-dev build-essential g++ libcunit1-dev curl htop tree wget libreadline6 libreadline6-dev
-COPY . /usr/src/so-commons-library
-WORKDIR /usr/src/so-commons-library/cspec
-RUN git clone https://github.com/mumuki/cspec . && git reset --hard 396445c217b366fd3a41c33a38e9a8dd75c3f0e5
-RUN make clean && make
+FROM gcc:11.2.0
+
 WORKDIR /usr/src/so-commons-library
-CMD [ "make", "test" ]
+
+RUN git clone https://github.com/mumuki/cspec \
+  && cd cspec \
+  && git reset --hard 396445c217b366fd3a41c33a38e9a8dd75c3f0e5
+
+COPY . ./
+
+RUN make install
+
+CMD [ "/bin/sh" ]

--- a/src/makefile
+++ b/src/makefile
@@ -5,6 +5,10 @@ C_SRCS=$(shell find . -iname "*.c" | tr '\n' ' ')
 H_SRCS=$(shell find . -iname "*.h" | tr '\n' ' ')
 OBJS=$(C_SRCS:./%.c=build/%.o)
 
+ifneq ($(shell id -un),root)
+SUDO=sudo
+endif
+
 # Clean and compile .so
 all: build/libcommons.so
 
@@ -30,11 +34,11 @@ clean:
 	$(RM) build
 
 install: all
-	sudo cp -u build/libcommons.so /usr/lib
-	sudo cp --parents -u $(H_SRCS) /usr/include
+	$(SUDO) cp -u build/libcommons.so /usr/lib
+	$(SUDO) cp --parents -u $(H_SRCS) /usr/include
 
 uninstall:
-	sudo rm -f /usr/lib/libcommons.so
-	sudo rm -rf /usr/include/commons
+	$(SUDO) rm -f /usr/lib/libcommons.so
+	$(SUDO) rm -rf /usr/include/commons
 
 .PHONY: all debug sources clean install uninstall


### PR DESCRIPTION
Las [nuevas VMs](../../entorno-vms) en Ubuntu 22.04 van a venir con gcc 11.2.0 instalado, por lo que parto de esa versión en el Dockerfile de prueba.