### PR TITLE
temporal_get_string_time: fix memory leak on error

### DIFF
--- a/src/commons/temporal.c
+++ b/src/commons/temporal.c
@@ -14,11 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "temporal.h"
-#include "error.h"
 #include "string.h"
 
-#include <unistd.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
@@ -32,14 +29,14 @@ char *temporal_get_string_time(const char* format) {
 	struct tm* log_tm = malloc(sizeof(struct tm));
 	char* milisec;
 
-	if(clock_gettime(CLOCK_REALTIME, log_timespec) == -1) {
+	if (clock_gettime(CLOCK_REALTIME, log_timespec) == -1) {
 		error_show("Error getting date!");
 		free(str_time);
 		return NULL;
 	}
 	milisec = string_from_format("%03ld", log_timespec->tv_nsec / 1000000);
 
-	for(char* ms = strstr(str_time, "%MS"); ms != NULL; ms = strstr(ms + 3, "%MS")) {
+	for (char* ms = strstr(str_time, "%MS"); ms != NULL; ms = strstr(ms + 3, "%MS")) {
 		memcpy(ms, milisec, 3);
 	}
 
@@ -57,7 +54,7 @@ t_temporal* temporal_create(void) {
 	t_temporal* self = malloc(sizeof(t_temporal));
 
 	self->elapsed_ms = 0;
-	self->state = TEMPORAL_STATUS_RUNNING;
+	self->status = TEMPORAL_STATUS_RUNNING;
 
 	clock_gettime(CLOCK_MONOTONIC_RAW, &self->current);
 
@@ -69,7 +66,7 @@ void temporal_destroy(t_temporal* temporal) {
 }
 
 int64_t temporal_gettime(t_temporal* temporal) {
-	if (temporal->state == TEMPORAL_STATUS_STOPPED) {
+	if (temporal->status == TEMPORAL_STATUS_STOPPED) {
 		return temporal->elapsed_ms;
 	}
 
@@ -79,20 +76,20 @@ int64_t temporal_gettime(t_temporal* temporal) {
 }
 
 void temporal_stop(t_temporal* temporal) {
-	if (temporal->state == TEMPORAL_STATUS_STOPPED) {
+	if (temporal->status == TEMPORAL_STATUS_STOPPED) {
 		return;
 	}
 
 	temporal->elapsed_ms += calculate_delta_ms(temporal);
-	temporal->state = TEMPORAL_STATUS_STOPPED;
+	temporal->status = TEMPORAL_STATUS_STOPPED;
 }
 
 void temporal_resume(t_temporal* temporal) {
-	if (temporal->state == TEMPORAL_STATUS_RUNNING) {
+	if (temporal->status == TEMPORAL_STATUS_RUNNING) {
 		return;
 	}
 
-	temporal->state = TEMPORAL_STATUS_RUNNING;
+	temporal->status = TEMPORAL_STATUS_RUNNING;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &temporal->current);
 }
 

--- a/src/commons/temporal.c
+++ b/src/commons/temporal.c
@@ -25,27 +25,25 @@ static int64_t calculate_delta_ms(t_temporal* temporal);
 char *temporal_get_string_time(const char* format) {
 	char* str_time = strdup(format);
 
-	struct timespec* log_timespec = malloc(sizeof(struct timespec));
-	struct tm* log_tm = malloc(sizeof(struct tm));
+	struct timespec log_timespec;
+	struct tm log_tm;
 	char* milisec;
 
-	if (clock_gettime(CLOCK_REALTIME, log_timespec) == -1) {
+	if (clock_gettime(CLOCK_REALTIME, &log_timespec) == -1) {
 		error_show("Error getting date!");
 		free(str_time);
 		return NULL;
 	}
-	milisec = string_from_format("%03ld", log_timespec->tv_nsec / 1000000);
+	milisec = string_from_format("%03ld", log_timespec.tv_nsec / 1000000);
 
 	for (char* ms = strstr(str_time, "%MS"); ms != NULL; ms = strstr(ms + 3, "%MS")) {
 		memcpy(ms, milisec, 3);
 	}
 
-	localtime_r(&log_timespec->tv_sec, log_tm);
-	strftime(str_time, strlen(format) + 1, str_time, log_tm);
+	localtime_r(&log_timespec.tv_sec, &log_tm);
+	strftime(str_time, strlen(format) + 1, str_time, &log_tm);
 
 	free(milisec);
-	free(log_tm);
-	free(log_timespec);
 
 	return str_time;
 }

--- a/src/commons/temporal.c
+++ b/src/commons/temporal.c
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "temporal.h"
+#include "error.h"
 #include "string.h"
 
 #include <stdlib.h>

--- a/src/commons/temporal.c
+++ b/src/commons/temporal.c
@@ -33,6 +33,8 @@ char *temporal_get_string_time(const char* format) {
 	char* milisec;
 
 	if(clock_gettime(CLOCK_REALTIME, log_timespec) == -1) {
+		error_show("Error getting date!");
+		free(str_time);
 		return NULL;
 	}
 	milisec = string_from_format("%03ld", log_timespec->tv_nsec / 1000000);
@@ -53,12 +55,12 @@ char *temporal_get_string_time(const char* format) {
 
 t_temporal* temporal_create(void) {
 	t_temporal* self = malloc(sizeof(t_temporal));
-	
+
 	self->elapsed_ms = 0;
 	self->state = TEMPORAL_STATUS_RUNNING;
-	
+
 	clock_gettime(CLOCK_MONOTONIC_RAW, &self->current);
-	
+
 	return self;
 }
 
@@ -70,7 +72,7 @@ int64_t temporal_gettime(t_temporal* temporal) {
 	if (temporal->state == TEMPORAL_STATUS_STOPPED) {
 		return temporal->elapsed_ms;
 	}
-	
+
 	int64_t delta_ms = calculate_delta_ms(temporal);
 
 	return delta_ms + temporal->elapsed_ms;
@@ -101,8 +103,8 @@ int64_t temporal_diff(t_temporal* temporal_1, t_temporal* temporal_2) {
 static int64_t calculate_delta_ms(t_temporal* temporal) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-	
+
 	int64_t delta_ms = (now.tv_sec - temporal->current.tv_sec) * 1000 + (now.tv_nsec - temporal->current.tv_nsec) / 1000000;
-	
+
 	return delta_ms;
 }

--- a/src/commons/temporal.h
+++ b/src/commons/temporal.h
@@ -20,6 +20,25 @@
 	#include <time.h>
 
 	/**
+	* @NAME: t_temporal_status
+	* @DESC: Estado de una variable temporal.
+	*/
+	typedef enum {
+		TEMPORAL_STATUS_STOPPED,
+		TEMPORAL_STATUS_RUNNING
+	} t_temporal_status;
+
+	/**
+	* @NAME: t_temporal
+	* @DESC: Estructura de una Variable temporal.
+	*/
+	typedef struct {
+		struct timespec current;
+		int64_t elapsed_ms;
+		t_temporal_status status;
+	} t_temporal;
+
+	/**
 	* @NAME: temporal_get_string_time
 	* @DESC: Retorna un string con la hora actual,
 	* con el formato recibido por parámetro.
@@ -29,25 +48,6 @@
 	* temporal_get_string_time("%d/%m/%y %H:%M:%S") => "30/09/20 12:51:59"
 	*/
 	char *temporal_get_string_time(const char* format);
-
-	/**
-	* @NAME: t_state
-	* @DESC: Estado de una variable temporal.
-	*/
-	typedef enum {
-		TEMPORAL_STATUS_STOPPED,
-		TEMPORAL_STATUS_RUNNING
-	} t_state;
-
-	/**
-	* @NAME: t_temporal
-	* @DESC: Estructura de una Variable temporal.
-	*/
-	typedef struct {
-		struct timespec current;
-		int64_t elapsed_ms;
-		t_state state;
-	} t_temporal;
 
 	/**
 	* @NAME: temporal_create

--- a/tests/integration-tests/temporal/main.c
+++ b/tests/integration-tests/temporal/main.c
@@ -106,7 +106,7 @@ void test_temporal_diff() {
 	temporal_destroy(temporal3);
 }
 
-void test_temporal_state() {
+void test_temporal_status() {
 	/**
 	* @DESC: Verificar el comportamiento del temporal en sus diferentes estados.
 	*        En este test se verifica que no ocurra ningún error al usar el temporal de cualquier forma.
@@ -128,7 +128,7 @@ void test_temporal_state() {
 	temporal_resume(temporal3);
 	sleep(1);
 
-	printf("test_temporal_state: %lums (expected: ~1000ms)\n\n", temporal_gettime(temporal3));
+	printf("test_temporal_status: %lums (expected: ~1000ms)\n\n", temporal_gettime(temporal3));
 
 	temporal_destroy(temporal3);
 }
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
 	test_temporal_stop();
 	test_temporal_resume();
 	test_temporal_diff();
-	test_temporal_state();
+	test_temporal_status();
 	
 	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
Si por algún motivo misterioso `clock_gettime` tira error, hay un memory leak en `temporal_get_string_time`. También incluí el mensajito que sin querer borré en #123 y acomodé un poco el código para que el formato sea igual al resto.
