### PR TITLE
List: Iterator replace

### DIFF
--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -23,7 +23,7 @@ static void            list_destroy_element(t_link_element* element);
 static void            list_link_element(t_list* self, t_link_element** indirect, void* data);
 static void            list_unlink_element(t_list* self, t_link_element** indirect);
 static t_list_iterator list_iterator_init(t_list* list);
-static void*           list_iterator_next_data(t_list_iterator *iterator);
+static void*           list_iterator_peek(t_list_iterator *iterator);
 static void            list_iterator_advance(t_list_iterator *iterator);
 static void            list_iterator_rewind(t_list_iterator *iterator);
 static void            list_iterator_advance_to_index(t_list_iterator* iterator, int index);
@@ -403,7 +403,7 @@ static t_list_iterator list_iterator_init(t_list* list) {
 	};
 }
 
-static void* list_iterator_next_data(t_list_iterator *iterator) {
+static void* list_iterator_peek(t_list_iterator *iterator) {
 	return (*iterator->next)->data;
 }
 
@@ -427,7 +427,7 @@ static void list_iterator_advance_to_index(t_list_iterator *iterator, int index)
 
 static bool list_iterator_advance_to_condition(t_list_iterator *iterator, bool(*condition)(void*)) {
 	while (list_iterator_has_next(iterator)) {
-		if (condition(list_iterator_next_data(iterator))) {
+		if (condition(list_iterator_peek(iterator))) {
 			return true;
 		}
 		list_iterator_advance(iterator);
@@ -444,7 +444,7 @@ static void list_iterator_add_all(t_list_iterator* iterator, t_list* other) {
 
 static int list_iterator_add_sorted(t_list_iterator *iterator, void *data, bool (*comparator)(void*,void*)) {
 	while (list_iterator_has_next(iterator)) {
-		if (comparator(data, list_iterator_next_data(iterator))) {
+		if (comparator(data, list_iterator_peek(iterator))) {
 			break;
 		}
 		list_iterator_advance(iterator);

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -18,17 +18,17 @@
 
 #include "list.h"
 
-static t_link_element *list_create_element(void* data);
-static void list_link_element(t_list* self, t_link_element** indirect, t_link_element* element);
-static t_link_element *list_unlink_element(t_list* self, t_link_element** indirect);
-static t_link_element **list_get_indirect_in_index(t_list *self, int index);
-static t_link_element **list_get_indirect_by_condition(t_list *self, bool(*condition)(void*));
-static void list_add_element(t_list *self, t_link_element **indirect, void *data);
-static void *list_replace_indirect(t_link_element **indirect, void *data);
-static void *list_remove_indirect(t_list *self, t_link_element **indirect);
-static void list_iterate_indirects(t_list* self, int start, int count, bool (*removed)(t_link_element**));
-static int list_add_element_sorted(t_list *self, t_link_element* element, bool (*comparator)(void*,void*));
-static void* list_fold_elements(t_link_element* element, void* seed, void*(*operation)(void*, void*));
+static t_link_element* list_create_element(void* data);
+static void            list_link_element(t_list* self, t_link_element** indirect, t_link_element* element);
+static t_link_element* list_unlink_element(t_list* self, t_link_element** indirect);
+static t_list_iterator list_iterator_init(t_list* list);
+static void            list_iterator_advance(t_list_iterator *iterator);
+static void            list_iterator_rewind(t_list_iterator *iterator);
+static void            list_iterator_advance_to_index(t_list_iterator* iterator, int index);
+static bool            list_iterator_advance_to_condition(t_list_iterator* iterator, bool(*condition)(void*));
+static void            list_iterator_apply_in_range(t_list *self, int start, int count, void (*callback)(t_list_iterator*));
+static int             list_iterator_add_sorted(t_list_iterator *iterator, void *data, bool (*comparator)(void*,void*));
+static void*           list_iterator_fold(t_list_iterator* iterator, void* seed, void*(*operation)(void*, void*));
 
 t_list *list_create() {
 	t_list *list = malloc(sizeof(t_list));
@@ -38,38 +38,54 @@ t_list *list_create() {
 }
 
 int list_add(t_list *self, void *data) {
-	t_link_element **indirect = list_get_indirect_in_index(self, list_size(self));
-	list_add_element(self, indirect, data);
-	return list_size(self) - 1;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, list_size(self));
+
+	list_iterator_add(&self_iterator, data);
+	return list_iterator_index(&self_iterator);
 }
 
 void list_add_all(t_list* self, t_list* other) {
-	t_link_element **indirect = list_get_indirect_in_index(self, list_size(self));
-	void _add_data(void *data) {
-		list_add_element(self, indirect, data);
-		indirect = &(*indirect)->next;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, list_size(self));
+
+	t_list_iterator other_iterator = list_iterator_init(other);
+	while (list_iterator_has_next(&other_iterator)) {
+		list_iterator_add(&self_iterator, list_iterator_next(&other_iterator));
 	}
-	list_iterate(other, _add_data);
 }
 
 void* list_get(t_list *self, int index) {
-	t_link_element **indirect = list_get_indirect_in_index(self, index);
-	return (*indirect)->data;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, index);
+
+	return list_iterator_next(&self_iterator);
 }
 
 void list_add_in_index(t_list *self, int index, void *data) {
-	t_link_element **indirect = list_get_indirect_in_index(self, index);
-	list_add_element(self, indirect, data);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, index);
+
+	list_iterator_add(&self_iterator, data);
 }
 
 void *list_replace(t_list *self, int index, void *data) {
-	t_link_element **indirect = list_get_indirect_in_index(self, index);
-	return list_replace_indirect(indirect, data);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, index);
+
+	void *old_data = list_iterator_next(&self_iterator);
+	list_iterator_replace(&self_iterator, data);
+	return old_data;
 }
 
 void *list_replace_by_condition(t_list* self, bool(*condition)(void*), void* element) {
-	t_link_element **indirect = list_get_indirect_by_condition(self, condition);
-	return (*indirect) != NULL ? list_replace_indirect(indirect, element) : NULL;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	if (list_iterator_advance_to_condition(&self_iterator, condition)) {
+		void *old_data = list_iterator_next(&self_iterator);
+		list_iterator_replace(&self_iterator, element);
+		return old_data;
+	}
+	return NULL;
 }
 
 void list_replace_and_destroy_element(t_list *self, int index, void *data, void(*element_destroyer)(void*)) {
@@ -78,33 +94,49 @@ void list_replace_and_destroy_element(t_list *self, int index, void *data, void(
 }
 
 void* list_find(t_list *self, bool(*condition)(void*)) {
-	t_link_element **indirect = list_get_indirect_by_condition(self, condition);
-	return (*indirect) != NULL ? (*indirect)->data : NULL;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	if (list_iterator_advance_to_condition(&self_iterator, condition)) {
+		return list_iterator_next(&self_iterator);
+	}
+	return NULL;
 }
 
 void list_iterate(t_list* self, void(*closure)(void*)) {
-	t_link_element **indirect = &self->head;
-	while ((*indirect) != NULL) {
-		closure((*indirect)->data);
-		indirect = &(*indirect)->next;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	while (list_iterator_has_next(&self_iterator)) {
+		closure(list_iterator_next(&self_iterator));
 	}
 }
 
 void *list_remove(t_list *self, int index) {
-	t_link_element **indirect = list_get_indirect_in_index(self, index);
-	return list_remove_indirect(self, indirect);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, index);
+	void *data = list_iterator_next(&self_iterator);
+	list_iterator_remove(&self_iterator);
+	return data;
 }
 
 bool list_remove_element(t_list *self, void *element) {
+	t_list_iterator self_iterator = list_iterator_init(self);
 	bool _is_the_element(void *data) {
 		return element == data;
 	}
-	return list_remove_by_condition(self, _is_the_element) != NULL;
+	if (list_iterator_advance_to_condition(&self_iterator, _is_the_element)) {
+		list_iterator_advance(&self_iterator);
+		list_iterator_remove(&self_iterator);
+		return true;
+	}
+	return false;
 }
 
 void* list_remove_by_condition(t_list *self, bool(*condition)(void*)) {
-	t_link_element **indirect = list_get_indirect_by_condition(self, condition);
-	return (*indirect) != NULL ? list_remove_indirect(self, indirect) : NULL;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	if (list_iterator_advance_to_condition(&self_iterator, condition)) {
+		void *data = list_iterator_next(&self_iterator);
+		list_iterator_remove(&self_iterator);
+		return data;
+	}
+	return NULL;
 }
 
 void list_remove_and_destroy_element(t_list *self, int index, void(*element_destroyer)(void*)) {
@@ -120,13 +152,13 @@ void list_remove_and_destroy_by_condition(t_list *self, bool(*condition)(void*),
 }
 
 void list_remove_and_destroy_all_by_condition(t_list *self, bool(*condition)(void*), void(*element_destroyer)(void*)) {
-	t_link_element **indirect = &self->head;
-	while ((*indirect) != NULL) {
-		if (condition((*indirect)->data)) {
-			element_destroyer(list_remove_indirect(self, indirect));
-			continue;
+	t_list_iterator self_iterator = list_iterator_init(self);
+	while (list_iterator_has_next(&self_iterator)) {
+		void* data = list_iterator_next(&self_iterator);
+		if (condition(data)) {
+			list_iterator_remove(&self_iterator);
+			element_destroyer(data);
 		}
-		indirect = &(*indirect)->next;
 	}
 }
 
@@ -139,8 +171,10 @@ bool list_is_empty(t_list *list) {
 }
 
 void list_clean(t_list *self) {
-	while (!list_is_empty(self)) {
-		list_remove_indirect(self, &self->head);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	while (list_iterator_has_next(&self_iterator)) {
+		list_iterator_advance(&self_iterator);
+		list_iterator_remove(&self_iterator);
 	}
 }
 
@@ -164,92 +198,92 @@ t_list* list_take(t_list* self, int count) {
 }
 
 t_list* list_slice(t_list* self, int start, int count) {
-	t_list* sublist = list_create();
-	t_link_element **sublist_indirect = &sublist->head;
+	t_list_iterator sublist_iterator = list_iterator_init(list_create());
 
-	bool _add_to_sublist(t_link_element **self_indirect) {
-		list_add_element(sublist, sublist_indirect, (*self_indirect)->data);
-		sublist_indirect = &(*sublist_indirect)->next;
-		return false;
+	void _add_to_sublist(t_list_iterator* self_iterator) {
+		list_iterator_add(&sublist_iterator, list_iterator_next(self_iterator));
 	}
-	list_iterate_indirects(self, start, count, _add_to_sublist);
+	list_iterator_apply_in_range(self, start, count, _add_to_sublist);
 
-	return sublist;
+	return sublist_iterator.list;
 }
 
 t_list* list_slice_and_remove(t_list* self, int start, int count) {
-	t_list* sublist = list_create();
-	t_link_element **sublist_indirect = &sublist->head;
+	t_list_iterator sublist_iterator = list_iterator_init(list_create());
 
-	bool _move_from_self_to_sublist(t_link_element **self_indirect) {
-		list_link_element(sublist, sublist_indirect, list_unlink_element(self, self_indirect));
-		sublist_indirect = &(*sublist_indirect)->next;
-		return true;
+	void _move_from_self_to_sublist(t_list_iterator* self_iterator) {
+		list_iterator_add(&sublist_iterator, list_iterator_next(self_iterator));
+		list_iterator_remove(self_iterator);
 	}
-	list_iterate_indirects(self, start, count, _move_from_self_to_sublist);
+	list_iterator_apply_in_range(self, start, count, _move_from_self_to_sublist);
 
-	return sublist;
+	return sublist_iterator.list;
 }
 
 t_list* list_take_and_remove(t_list* self, int count) {
 	return list_slice_and_remove(self, 0, count);
 }
 
-t_list* list_filter(t_list* self, bool(*condition)(void*)){
-	t_list *sublist = list_create();
-	t_link_element **indirect = &sublist->head;
+t_list* list_filter(t_list* self, bool(*condition)(void*)) {
+	t_list_iterator sublist_iterator = list_iterator_init(list_create());
 
 	void _add_by_condition(void* data) {
 		if (condition(data)) {
-			list_add_element(sublist, indirect, data);
-			indirect = &(*indirect)->next;
+			list_iterator_add(&sublist_iterator, data);
 		}
 	}
 	list_iterate(self, _add_by_condition);
 
-	return sublist;
+	return sublist_iterator.list;
 }
 
 t_list* list_map(t_list* self, void*(*transformer)(void*)){
-	t_list *sublist = list_create();
-	t_link_element **indirect = &sublist->head;
+	t_list_iterator transformed_iterator = list_iterator_init(list_create());
 
 	void _map_data(void* data) {
-		list_add_element(sublist, indirect, transformer(data));
-		indirect = &(*indirect)->next;
+		list_iterator_add(&transformed_iterator, transformer(data));
 	}
 	list_iterate(self, _map_data);
 
-	return sublist;
+	return transformed_iterator.list;
 }
 
 t_list* list_flatten(t_list* self) {
-	t_list *sublist = list_create();
-	t_link_element **indirect = &sublist->head;
+	t_list_iterator flattened_iterator = list_iterator_init(list_create());
 
 	void _flatten_data(t_list* list) {
 		void _add_data(void* data) {
-			list_add_element(sublist, indirect, data);
-			indirect = &(*indirect)->next;
+			list_iterator_add(&flattened_iterator, data);
 		}
 		list_iterate(list, (void*) _add_data);
 	}
 	list_iterate(self, (void*) _flatten_data);
 
-	return sublist;
+	return flattened_iterator.list;
 }
 
 int list_add_sorted(t_list *self, void* data, bool (*comparator)(void*,void*)) {
-	return list_add_element_sorted(self, list_create_element(data), comparator);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	return list_iterator_add_sorted(&self_iterator, data, comparator);
 }
 
-void list_sort(t_list *self, bool (*comparator)(void *, void *)) {
-	t_list *aux = list_create();
-	while (!list_is_empty(self)) {
-		list_add_element_sorted(aux, list_unlink_element(self, &self->head), comparator);
+void list_sort(t_list *right, bool (*comparator)(void *, void *)) {
+	if (list_size(right) < 2) {
+		return;
 	}
-	*self = *aux;
-	free(aux);
+
+	t_list *left = list_take_and_remove(right, list_size(right) / 2);
+
+	list_sort(left, comparator);
+	list_sort(right, comparator);
+
+	t_list_iterator right_iterator = list_iterator_init(right);
+	void _add_sorted_to_right(void *data) {
+		list_iterator_add_sorted(&right_iterator, data, comparator);
+	}
+	list_iterate(left, _add_sorted_to_right);
+
+	list_destroy(left);
 }
 
 t_list* list_sorted(t_list* self, bool (*comparator)(void *, void *)) {
@@ -269,12 +303,13 @@ int list_count_satisfying(t_list* self, bool(*condition)(void*)){
 	return result;
 }
 
-bool list_any_satisfy(t_list* self, bool(*condition)(void*)){
-	return list_count_satisfying(self, condition) > 0;
+bool list_any_satisfy(t_list* self, bool(*condition)(void*)) {
+	t_list_iterator self_iterator = list_iterator_init(self);
+	return list_iterator_advance_to_condition(&self_iterator, condition);
 }
 
-bool list_all_satisfy(t_list* self, bool(*condition)(void*)){
-	return list_count_satisfying(self, condition) == self->elements_count;
+bool list_all_satisfy(t_list* self, bool(*condition)(void*)) {
+	return list_count_satisfying(self, condition) == list_size(self);
 }
 
 t_list* list_duplicate(t_list* self) {
@@ -284,11 +319,13 @@ t_list* list_duplicate(t_list* self) {
 }
 
 void* list_fold1(t_list* self, void* (*operation)(void*, void*)) {
-	return list_fold_elements(self->head->next, self->head->data, operation);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	return list_iterator_fold(&self_iterator, list_iterator_next(&self_iterator), operation);
 }
 
 void* list_fold(t_list* self, void* seed, void*(*operation)(void*, void*)) {
-	return list_fold_elements(self->head, seed, operation);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	return list_iterator_fold(&self_iterator, seed, operation);
 }
 
 void* list_get_minimum(t_list* self, void* (*minimum)(void*, void*)) {
@@ -301,10 +338,7 @@ void* list_get_maximum(t_list* self, void* (*maximum)(void*, void*)) {
 
 t_list_iterator* list_iterator_create(t_list* list) {
 	t_list_iterator* new = malloc(sizeof(t_list_iterator));
-	new->list = list;
-	new->actual = NULL;
-	new->next = &list->head;
-	new->index = -1;
+	*new = list_iterator_init(list);
 	return new;
 }
 
@@ -313,9 +347,7 @@ bool list_iterator_has_next(t_list_iterator* iterator) {
 }
 
 void* list_iterator_next(t_list_iterator* iterator) {
-	iterator->actual = iterator->next;
-	iterator->next = &(*iterator->next)->next;
-	iterator->index++;
+	list_iterator_advance(iterator);
 	return (*iterator->actual)->data;
 }
 
@@ -324,16 +356,17 @@ int list_iterator_index(t_list_iterator* iterator) {
 }
 
 void list_iterator_add(t_list_iterator* iterator, void *data) {
-	iterator->actual = iterator->next;
-	list_add_element(iterator->list, iterator->actual, data);
-	iterator->next = &(*iterator->actual)->next;
-	iterator->index++;
+	list_link_element(iterator->list, iterator->next, list_create_element(data));
+	list_iterator_advance(iterator);
 }
 
 void list_iterator_remove(t_list_iterator* iterator) {
-	list_remove_indirect(iterator->list, iterator->actual);
-	iterator->next = iterator->actual;
-	iterator->index--;
+	list_iterator_rewind(iterator);
+	free(list_unlink_element(iterator->list, iterator->next));
+}
+
+void list_iterator_replace(t_list_iterator* iterator, void *data) {
+	(*iterator->actual)->data = data;
 }
 
 void list_iterator_destroy(t_list_iterator* iterator) {
@@ -362,68 +395,64 @@ static t_link_element* list_unlink_element(t_list* self, t_link_element** indire
 	return element;
 }
 
-static t_link_element **list_get_indirect_in_index(t_list *self, int index) {
-	t_link_element **indirect = &self->head;
-	for (int i = 0; i < index; ++i) {
-		indirect = &(*indirect)->next;
+static t_list_iterator list_iterator_init(t_list* list) {
+	return (t_list_iterator) {
+		.list = list,
+		.actual = NULL,
+		.next = &list->head,
+		.index = -1
+	};
+}
+
+static void list_iterator_advance(t_list_iterator *iterator) {
+	iterator->actual = iterator->next;
+	iterator->index++;
+	iterator->next = &(*iterator->actual)->next;
+}
+
+static void list_iterator_rewind(t_list_iterator *iterator) {
+	iterator->next = iterator->actual;
+	iterator->actual = NULL;
+	iterator->index--;
+}
+
+static void list_iterator_advance_to_index(t_list_iterator *iterator, int index) {
+	while (list_iterator_index(iterator) < index - 1) {
+		list_iterator_advance(iterator);
 	}
-	return indirect;
 }
 
-static t_link_element **list_get_indirect_by_condition(t_list *self, bool(*condition)(void*)) {
-	t_link_element** indirect = &self->head;
-	while ((*indirect) != NULL && !condition((*indirect)->data)) {
-		indirect = &(*indirect)->next;
-	}
-	return indirect;
-}
-
-static void list_add_element(t_list *self, t_link_element **indirect, void *data) {
-	list_link_element(self, indirect, list_create_element(data));
-}
-
-static void *list_replace_indirect(t_link_element **indirect, void *data) {
-	void *old_data = (*indirect)->data;
-	(*indirect)->data = data;
-	return old_data;
-}
-
-static void *list_remove_indirect(t_list *self, t_link_element **indirect) {
-	t_link_element *element = list_unlink_element(self, indirect);
-	void *data = element->data;
-	free(element);
-	return data;
-}
-
-static void list_iterate_indirects(t_list *self, int start, int count, bool (*removed)(t_link_element**)) {
-	t_link_element **indirect = list_get_indirect_in_index(self, start);
-	int i = 0;
-	while ((i < count) && (*indirect) != NULL) {
-		if (!removed(indirect)) {
-			indirect = &(*indirect)->next;
+static bool list_iterator_advance_to_condition(t_list_iterator *iterator, bool(*condition)(void*)) {
+	while (list_iterator_has_next(iterator)) {
+		if (condition((*iterator->next)->data)) {
+			return true;
 		}
-		++i;
+		list_iterator_advance(iterator);
+	}
+	return false;
+}
+
+static void list_iterator_apply_in_range(t_list *self, int start, int count, void (*callback)(t_list_iterator*)) {
+	t_list_iterator self_iterator = list_iterator_init(self);
+	list_iterator_advance_to_index(&self_iterator, start);
+	for (int i = 0; i < count && list_iterator_has_next(&self_iterator); ++i) {
+		callback(&self_iterator);
 	}
 }
 
-static int list_add_element_sorted(t_list *self, t_link_element* element, bool (*comparator)(void*,void*)) {
-	t_link_element **indirect = &self->head;
-	int index = 0;
-	while ((*indirect) != NULL && comparator((*indirect)->data, element->data)) {
-		indirect = &(*indirect)->next;
-		index++;
+static int list_iterator_add_sorted(t_list_iterator *iterator, void *data, bool (*comparator)(void*,void*)) {
+	bool _should_be_after_data(void *element_data) {
+		return comparator(data, element_data);
 	}
-	list_link_element(self, indirect, element);
-
-	return index;
+	list_iterator_advance_to_condition(iterator, _should_be_after_data);
+	list_iterator_add(iterator, data);
+	return list_iterator_index(iterator);
 }
 
-static void* list_fold_elements(t_link_element* element, void* seed, void*(*operation)(void*, void*)) {
-	void* result = seed;
-	while (element != NULL) {
-		result = operation(result, element->data);
-		element = element->next;
+static void *list_iterator_fold(t_list_iterator* iterator, void* seed, void*(*operation)(void*, void*)) {
+	void *result = seed;
+	while (list_iterator_has_next(iterator)) {
+		result = operation(result, list_iterator_next(iterator));
 	}
-
 	return result;
 }

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -25,7 +25,7 @@ static void            list_unlink_element(t_list* self, t_link_element** indire
 static t_list_iterator list_iterator_init(t_list* list);
 static void*           list_iterator_peek(t_list_iterator *iterator);
 static void            list_iterator_advance(t_list_iterator *iterator);
-static void            list_iterator_rewind(t_list_iterator *iterator);
+static void            list_iterator_retreat(t_list_iterator *iterator);
 static void            list_iterator_advance_to_index(t_list_iterator* iterator, int index);
 static bool            list_iterator_advance_to_condition(t_list_iterator* iterator, bool(*condition)(void*));
 static void            list_iterator_add_all(t_list_iterator* iterator, t_list* other);
@@ -357,7 +357,7 @@ void list_iterator_add(t_list_iterator* iterator, void *data) {
 }
 
 void list_iterator_remove(t_list_iterator* iterator) {
-	list_iterator_rewind(iterator);
+	list_iterator_retreat(iterator);
 	list_unlink_element(iterator->list, iterator->next);
 }
 
@@ -413,14 +413,14 @@ static void list_iterator_advance(t_list_iterator *iterator) {
 	iterator->next = &(*iterator->actual)->next;
 }
 
-static void list_iterator_rewind(t_list_iterator *iterator) {
+static void list_iterator_retreat(t_list_iterator *iterator) {
 	iterator->next = iterator->actual;
 	iterator->actual = NULL;
 	iterator->index--;
 }
 
 static void list_iterator_advance_to_index(t_list_iterator *iterator, int index) {
-	while (list_iterator_index(iterator) + 1 < index) {
+	while (list_iterator_index(iterator) < (index - 1)) {
 		list_iterator_advance(iterator);
 	}
 }

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -299,7 +299,13 @@ bool list_any_satisfy(t_list* self, bool(*condition)(void*)) {
 }
 
 bool list_all_satisfy(t_list* self, bool(*condition)(void*)) {
-	return list_count_satisfying(self, condition) == list_size(self);
+	t_list_iterator self_iterator = list_iterator_init(self);
+	while (list_iterator_has_next(&self_iterator)) {
+		if (!condition(list_iterator_next(&self_iterator))) {
+			return false;
+		}
+	}
+	return true;
 }
 
 t_list* list_duplicate(t_list* self) {
@@ -402,8 +408,8 @@ static void* list_iterator_next_data(t_list_iterator *iterator) {
 }
 
 static void list_iterator_advance(t_list_iterator *iterator) {
-	iterator->actual = iterator->next;
 	iterator->index++;
+	iterator->actual = iterator->next;
 	iterator->next = &(*iterator->actual)->next;
 }
 

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -190,24 +190,26 @@ t_list* list_take(t_list* self, int count) {
 }
 
 t_list* list_slice(t_list* self, int start, int count) {
-	t_list_iterator sublist_iterator = list_iterator_init(list_create());
+	t_list *sublist = list_create();
+	t_list_iterator sublist_iterator = list_iterator_init(sublist);
 	t_list_iterator self_iterator = list_iterator_init(self);
 	list_iterator_advance_to_index(&self_iterator, start);
 	for (int i = 0; i < count && list_iterator_has_next(&self_iterator); ++i) {
 		list_iterator_add(&sublist_iterator, list_iterator_next(&self_iterator));
 	}
-	return sublist_iterator.list;
+	return sublist;
 }
 
 t_list* list_slice_and_remove(t_list* self, int start, int count) {
-	t_list_iterator sublist_iterator = list_iterator_init(list_create());
+	t_list *sublist = list_create();
+	t_list_iterator sublist_iterator = list_iterator_init(sublist);
 	t_list_iterator self_iterator = list_iterator_init(self);
 	list_iterator_advance_to_index(&self_iterator, start);
 	for (int i = 0; i < count && list_iterator_has_next(&self_iterator); ++i) {
 		list_iterator_add(&sublist_iterator, list_iterator_next(&self_iterator));
 		list_iterator_remove(&self_iterator);
 	}
-	return sublist_iterator.list;
+	return sublist;
 }
 
 t_list* list_take_and_remove(t_list* self, int count) {
@@ -215,7 +217,8 @@ t_list* list_take_and_remove(t_list* self, int count) {
 }
 
 t_list* list_filter(t_list* self, bool(*condition)(void*)) {
-	t_list_iterator sublist_iterator = list_iterator_init(list_create());
+	t_list *sublist = list_create();
+	t_list_iterator sublist_iterator = list_iterator_init(sublist);
 	t_list_iterator self_iterator = list_iterator_init(self);
 	while (list_iterator_has_next(&self_iterator)) {
 		void* data = list_iterator_next(&self_iterator);
@@ -223,20 +226,22 @@ t_list* list_filter(t_list* self, bool(*condition)(void*)) {
 			list_iterator_add(&sublist_iterator, data);
 		}
 	}
-	return sublist_iterator.list;
+	return sublist;
 }
 
 t_list* list_map(t_list* self, void*(*transformer)(void*)){
-	t_list_iterator transformed_iterator = list_iterator_init(list_create());
+	t_list *transformed = list_create();
+	t_list_iterator transformed_iterator = list_iterator_init(transformed);
 	t_list_iterator self_iterator = list_iterator_init(self);
 	while (list_iterator_has_next(&self_iterator)) {
 		list_iterator_add(&transformed_iterator, transformer(list_iterator_next(&self_iterator)));
 	}
-	return transformed_iterator.list;
+	return transformed;
 }
 
 t_list* list_flatten(t_list* self) {
-	t_list_iterator flattened_iterator = list_iterator_init(list_create());
+	t_list *flattened = list_create();
+	t_list_iterator flattened_iterator = list_iterator_init(flattened);
 	t_list_iterator self_iterator = list_iterator_init(self);
 	while (list_iterator_has_next(&self_iterator)) {
 		t_list_iterator sublist_iterator = list_iterator_init(list_iterator_next(&self_iterator));
@@ -244,7 +249,7 @@ t_list* list_flatten(t_list* self) {
 			list_iterator_add(&flattened_iterator, list_iterator_next(&sublist_iterator));
 		}
 	}
-	return flattened_iterator.list;
+	return flattened;
 }
 
 int list_add_sorted(t_list *self, void* data, bool (*comparator)(void*,void*)) {

--- a/src/commons/collections/list.c
+++ b/src/commons/collections/list.c
@@ -28,6 +28,7 @@ static void            list_iterator_advance(t_list_iterator *iterator);
 static void            list_iterator_retreat(t_list_iterator *iterator);
 static void            list_iterator_advance_to_index(t_list_iterator* iterator, int index);
 static bool            list_iterator_advance_to_condition(t_list_iterator* iterator, bool(*condition)(void*));
+static void            list_iterator_advance_to_end(t_list_iterator* iterator);
 static void            list_iterator_add_all(t_list_iterator* iterator, t_list* other);
 static int             list_iterator_add_sorted(t_list_iterator *iterator, void *data, bool (*comparator)(void*,void*));
 static void*           list_iterator_fold(t_list_iterator* iterator, void* seed, void*(*operation)(void*, void*));
@@ -41,14 +42,14 @@ t_list *list_create() {
 
 int list_add(t_list *self, void *data) {
 	t_list_iterator self_iterator = list_iterator_init(self);
-	list_iterator_advance_to_index(&self_iterator, list_size(self));
+	list_iterator_advance_to_end(&self_iterator);
 	list_iterator_add(&self_iterator, data);
 	return list_iterator_index(&self_iterator);
 }
 
 void list_add_all(t_list* self, t_list* other) {
 	t_list_iterator self_iterator = list_iterator_init(self);
-	list_iterator_advance_to_index(&self_iterator, list_size(self));
+	list_iterator_advance_to_end(&self_iterator);
 	list_iterator_add_all(&self_iterator, other);
 }
 
@@ -433,6 +434,12 @@ static bool list_iterator_advance_to_condition(t_list_iterator *iterator, bool(*
 		list_iterator_advance(iterator);
 	}
 	return false;
+}
+
+static void list_iterator_advance_to_end(t_list_iterator* iterator) {
+	while (list_iterator_has_next(iterator)) {
+		list_iterator_advance(iterator);
+	}
 }
 
 static void list_iterator_add_all(t_list_iterator* iterator, t_list* other) {

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -1061,6 +1061,8 @@
 	 * @note El elemento removido es el último devuelto por `list_iterator_next()`
 	 *       y dejará de pertenecer a la lista, por lo que debe ser liberado
 	 *       una vez que no se lo necesite.
+	 * @warning Solo se puede llamar a `list_iterator_remove()` una vez por cada
+	 *          llamada a `list_iterator_next()`.
 	 */
 	void list_iterator_remove(t_list_iterator* iterator);
 
@@ -1068,7 +1070,7 @@
 	 * @brief Reemplaza el elemento actual de la iteración por otro
 	 * @param data: El elemento a agregar. Este elemento pasará a pertenecer
 	 *        a la lista, por lo que no debe ser liberado por fuera de ésta.
-	 * @note El elemento removido es el último devuelto por list_iterator_next()
+	 * @note El elemento removido es el último devuelto por `list_iterator_next()`
 	 *       y dejará de pertenecer a la lista, por lo que debe ser liberado
 	 *       una vez que no se lo necesite.
 	 */

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -162,6 +162,7 @@
 	* @param comparator: Funcion que compara dos elementos. Debe devolver
 	*                    true si el primer parametro debe aparecer antes que el
 	*                    segundo en la lista
+ 	* @return El índice en el que se agregó el elemento
 	*
 	* Ejemplo de uso:
 	* @code
@@ -1040,6 +1041,7 @@
 	 * @return El elemento actual de la iteración. Pertenecerá a la lista,
 	 *         por lo que no debe ser liberado por fuera de ésta a menos que
 	 *         se lo remueva con `list_iterator_remove()`.
+  	 * @note Invocar esta función solo si `list_iterator_has_next()` es true.
 	 */
 	void* list_iterator_next(t_list_iterator* iterator);
 
@@ -1053,16 +1055,19 @@
 	 *        del siguiente. Luego, avanza hacia el elemento agregado.
 	 * @param data: El elemento a agregar. Este elemento pasará a pertenecer
 	 *        a la lista, por lo que no debe ser liberado por fuera de ésta.
+  	 * @note Invocar esta función luego de obtener el elemento actual
+	 *       con `list_iterator_next()`
 	 */
 	void list_iterator_add(t_list_iterator* iterator, void *data);
 
 	/**
 	 * @brief Remueve de la lista al elemento actual de la iteración
-	 * @note El elemento removido es el último devuelto por `list_iterator_next()`
-	 *       y dejará de pertenecer a la lista, por lo que debe ser liberado
-	 *       una vez que no se lo necesite.
+	 * @note Invocar esta función luego de obtener el elemento actual
+	 *       con `list_iterator_next()`. El elemento removido es el último
+	 *       devuelto por dicha función y dejará de pertenecer a la lista,
+	 *       por lo que debe ser liberado una vez que no se lo necesite.
 	 * @warning Solo se puede llamar a `list_iterator_remove()` una vez por cada
-	 *          llamada a `list_iterator_next()`.
+	 *          llamado a `list_iterator_next()`.
 	 */
 	void list_iterator_remove(t_list_iterator* iterator);
 
@@ -1070,9 +1075,10 @@
 	 * @brief Reemplaza el elemento actual de la iteración por otro
 	 * @param data: El elemento a agregar. Este elemento pasará a pertenecer
 	 *        a la lista, por lo que no debe ser liberado por fuera de ésta.
-	 * @note El elemento removido es el último devuelto por `list_iterator_next()`
-	 *       y dejará de pertenecer a la lista, por lo que debe ser liberado
-	 *       una vez que no se lo necesite.
+	 * @note Invocar esta función luego de obtener el elemento actual
+	 *       con `list_iterator_next()`. El elemento removido es el último
+	 *       devuelto por dicha función y dejará de pertenecer a la lista,
+	 *       por lo que debe ser liberado una vez que no se lo necesite.
 	 */
 	void list_iterator_replace(t_list_iterator* iterator, void *data);
 

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -1021,8 +1021,8 @@
 	 * t_list_iterator* iterator = list_iterator_create(list);
 	 * while(list_iterator_has_next(iterator)) {
 	 *     void* element = list_iterator_next(iterator);
-	 *     // Hacer algo que requiera list_iterator_add() o list_iterator_remove()
-	 *     // o romper la iteración con break o return
+	 *     // Modificar la lista con list_iterator_add(), list_iterator_replace() o list_iterator_remove()
+	 *     // y/o romper la iteración con un break o return
 	 * }
 	 * list_iterator_destroy(iterator);
 	 * @endcode

--- a/src/commons/collections/list.h
+++ b/src/commons/collections/list.h
@@ -1065,6 +1065,16 @@
 	void list_iterator_remove(t_list_iterator* iterator);
 
 	/**
+	 * @brief Reemplaza el elemento actual de la iteración por otro
+	 * @param data: El elemento a agregar. Este elemento pasará a pertenecer
+	 *        a la lista, por lo que no debe ser liberado por fuera de ésta.
+	 * @note El elemento removido es el último devuelto por list_iterator_next()
+	 *       y dejará de pertenecer a la lista, por lo que debe ser liberado
+	 *       una vez que no se lo necesite.
+	 */
+	void list_iterator_replace(t_list_iterator* iterator, void *data);
+
+	/**
 	 * @brief Finaliza la instancia de iteración externa liberando sus recursos
 	 * @note Esta operación no libera la lista ni sus elementos.
 	 */

--- a/tests/unit-tests/test_list.c
+++ b/tests/unit-tests/test_list.c
@@ -955,6 +955,61 @@ context (test_list) {
             } end
         } end
 
+        describe ("Replace") {
+            void _replace_all_by_name(char *filter) {
+                char *names[] = { "Matias", "Gaston", "Sebastian", "Daniela" };
+                int i = 0;
+
+                while(list_iterator_has_next(list_iterator)) {
+                    t_person* person = list_iterator_next(list_iterator);
+                    should_string(person->name) be equal to (names[i++]);
+
+                    if (string_contains(person->name, filter)) {
+                        list_iterator_replace(list_iterator, persona_create("Agustin", 23));
+                        persona_destroy(person);
+                    }
+                }
+            }
+
+            before {
+                list_add(list, persona_create("Matias"   , 24));
+                list_add(list, persona_create("Gaston"   , 25));
+                list_add(list, persona_create("Sebastian", 21));
+                list_add(list, persona_create("Daniela"  , 19));
+            } end
+
+            it("Should replace first element") {
+                _replace_all_by_name("Matias");
+
+                should_int(list->elements_count) be equal to (4);
+                assert_person_in_list(list, 0, "Agustin"  , 23);
+                assert_person_in_list(list, 1, "Gaston"   , 25);
+                assert_person_in_list(list, 2, "Sebastian", 21);
+                assert_person_in_list(list, 3, "Daniela"  , 19);
+            } end
+
+            it("Should replace an element in the middle") {
+                _replace_all_by_name("Gaston");
+
+                should_int(list->elements_count) be equal to (4);
+                assert_person_in_list(list, 0, "Matias"   , 24);
+                assert_person_in_list(list, 1, "Agustin"  , 23);
+                assert_person_in_list(list, 2, "Sebastian", 21);
+                assert_person_in_list(list, 3, "Daniela"  , 19);
+            } end
+
+            it("Should replace last element") {
+                _replace_all_by_name("Daniela");
+
+                should_int(list->elements_count) be equal to (4);
+                assert_person_in_list(list, 0, "Matias"   , 24);
+                assert_person_in_list(list, 1, "Gaston"   , 25);
+                assert_person_in_list(list, 2, "Sebastian", 21);
+                assert_person_in_list(list, 3, "Agustin"  , 23);
+            } end
+
+        } end
+
     } end
 
 }


### PR DESCRIPTION
Bueno resulta que hace unos meses arranqué por implementar un `list_iterator_replace()` y terminé reescribiendo toda la implementación de listas usando el iterador 😅 

La verdad que no me había gustado cómo había quedado la implementación actual: la lógica para recorrerla está en cada función por lo que es complicada de leer y explicar (y aparte tiene nested functions, lo cual en Alpine Linux [trae problemas](https://github.com/sisoputnfrba/entorno-vms/pull/12)). Ahora si quisiera mostrarle a un alumno "mirá, así funciona" _creo_ que es más sencillo:


```c
void *list_replace(t_list *self, int index, void *data) {
	t_list_iterator self_iterator = list_iterator_init(self);
	list_iterator_advance_to_index(&self_iterator, index);
	void *old_data = list_iterator_next(&self_iterator);
	list_iterator_replace(&self_iterator, data);
	return old_data;
}
```

1. Me guardo todo lo que necesito para iterar
2. Voy avanzando el iterador hasta el índice
3. Reemplazo el puntero actual con el nuevo y lo devuelvo


```c
void *list_replace_by_condition(t_list* self, bool(*condition)(void*), void* element) {
	t_list_iterator self_iterator = list_iterator_init(self);
	if (list_iterator_advance_to_condition(&self_iterator, condition)) {
		void *old_data = list_iterator_next(&self_iterator);
		list_iterator_replace(&self_iterator, element);
		return old_data;
	}
	return NULL;
}
```

1. Me guardo todo lo que necesito para iterar
2. Voy avanzando el puntero hasta que se cumpla la condición
3. Si se cumple, reemplazo el puntero actual con el nuevo y lo devuelvo
4. Si no se cumple, devuelvo NULL

Lo piola es que estas abstracciones ahora se usan tanto para buscar, agregar, reemplazar y quitar elementos en la lista.