### PR TITLE
fix: Logger memory leak and integration tests

### DIFF
--- a/src/commons/log.c
+++ b/src/commons/log.c
@@ -56,6 +56,7 @@ t_log* log_create(char* file, char *program_name, bool is_active_console, t_log_
 	if (file != NULL) {
 		if (!string_ends_with(file, ".log")) {
 			error_show("Log file must have .log extension");
+			free(logger);
 			return NULL;
 		}
 		file_opened = txt_open_for_append(file);

--- a/tests/integration-tests/logger/main.c
+++ b/tests/integration-tests/logger/main.c
@@ -35,12 +35,12 @@ int main(int argc, char** argv) {
     close(mkstemp(temp_file));
 
     if (temp_file != NULL) {
-        pthread_create(&th1, NULL, (void*) log_in_disk, string_duplicate(temp_file));
-        pthread_create(&th2, NULL, (void*) log_in_disk, string_duplicate(temp_file));
+        pthread_create(&th1, NULL, (void*) log_in_disk, string_from_format("%s.log", temp_file));
+        pthread_create(&th2, NULL, (void*) log_in_disk, string_from_format("%s.log", temp_file));
 
         pthread_join(th1, NULL);
         pthread_join(th2, NULL);
-        printf("\nRevisar el archivo de log que se creo en: %s\n", temp_file);
+        printf("\nRevisar el archivo de log que se creo en: %s.log\n", temp_file);
     } else {
         printf("No se pudo generar el archivo de log\n");
     }


### PR DESCRIPTION
relates to #192

- Los integration tests estaban fallando porque no tenían la extensión `.log` al final.
- Agrego un `free()`