### PR TITLE
fix: Download CSpec locally and remove crypto library linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 test_save_config.cfg
 .idea
 .DS_Store
+cspec

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Esta biblioteca depende de las siguientes bibliotecas:
 
 ## Guía para el uso
 
-1. Linkear con `-lcommons` y `-lcrypto`
+1. Linkear con `-lcommons`
 
 2. Para usarla en un .c/.h deberá incluirse de la siguiente forma: `commons/<Nombre_TAD>`
 
@@ -62,5 +62,5 @@ Por ejemplo:
 
 1. Ir a las Properties del proyecto (en el Project Explorer - la columna de la izquierda - la opción aparece dándole click derecho al proyecto), y dentro de la categoría `C/C++ Build` entrar a `Settings`, y ahí a `Tool Settings`.
 2. Buscar `GCC Linker` > `Libraries` > `Libraries`. Notar que entre paréntesis dice `-l`, el parámetro de `gcc` que estamos buscando.
-3. Darle click en el botón de `+`, y poner el nombre de la biblioteca sin el `-l` (en este caso, `commons` y `crypto`).
+3. Darle click en el botón de `+`, y poner el nombre de la biblioteca sin el `-l` (en este caso, `commons`).
 4. Aceptar y buildear el proyecto.

--- a/commons.code-workspace
+++ b/commons.code-workspace
@@ -1,26 +1,45 @@
 {
-	"settings": {
-		"debug.onTaskErrors": "abort",
-		"files.associations": {
-			"*.h": "c",
-		},
-		"C_Cpp.errorSquiggles": "disabled",
-	},
-	"folders": [
-		{
-			"path": "src"
-		},
-		{
-			"path": "tests/unit-tests"
-		},
-		{
-			"path": "tests/integration-tests/temporal"
-		},
-		{
-			"path": "tests/integration-tests/logger"
-		},
-		{
-			"path": "docs"
-		},
-	]
+  "settings": {
+    "debug.onTaskErrors": "abort",
+    "files.associations": {
+      "*.h": "c"
+    },
+    "files.exclude": {
+      ".github/**": true,
+      "docs/**": true,
+      "src/**": true,
+      "tests/**": true
+    },
+    "C_Cpp.errorSquiggles": "disabled"
+  },
+  "folders": [
+    {
+      "path": ".github",
+      "name": ".github"
+    },
+    {
+      "path": "src",
+			"name": "src"
+    },
+    {
+      "path": "tests/unit-tests",
+			"name": "tests/unit-tests"
+    },
+    {
+      "path": "tests/integration-tests/temporal",
+			"name": "tests/temporal"
+    },
+    {
+      "path": "tests/integration-tests/logger",
+      "name": "tests/logger"
+    },
+    {
+      "path": "docs",
+      "name": "docs"
+    },
+    {
+      "path": ".",
+			"name": "so-commons-library"
+    }
+  ]
 }

--- a/commons.code-workspace
+++ b/commons.code-workspace
@@ -19,15 +19,15 @@
     },
     {
       "path": "src",
-			"name": "src"
+      "name": "src"
     },
     {
       "path": "tests/unit-tests",
-			"name": "tests/unit-tests"
+      "name": "tests/unit-tests"
     },
     {
       "path": "tests/integration-tests/temporal",
-			"name": "tests/temporal"
+      "name": "tests/temporal"
     },
     {
       "path": "tests/integration-tests/logger",
@@ -39,7 +39,7 @@
     },
     {
       "path": ".",
-			"name": "so-commons-library"
+      "name": "so-commons-library"
     }
   ]
 }

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 all:
-	-cd src && $(MAKE) all
-	-cd tests/unit-tests && $(MAKE) all
+	cd src && $(MAKE) all
+	cd tests/unit-tests && $(MAKE) all
 
 clean:
 	-cd src && $(MAKE) clean
@@ -8,14 +8,14 @@ clean:
 	-cd docs && $(MAKE) clean
 
 debug:
-	-cd src && $(MAKE) debug
-	-cd tests/unit-tests && $(MAKE) debug
+	cd src && $(MAKE) debug
+	cd tests/unit-tests && $(MAKE) debug
 
 test: all
 	cd tests/unit-tests && $(MAKE) test
 
 install: test
-	-cd src && $(MAKE) install
+	cd src && $(MAKE) install
 
 uninstall:
 	-cd src && $(MAKE) uninstall
@@ -24,6 +24,6 @@ valgrind: debug
 	cd tests/unit-tests && $(MAKE) valgrind
 
 docs:
-	-cd docs && $(MAKE) all
+	cd docs && $(MAKE) all
 
 .PHONY: all clean debug test install uninstall valgrind docs

--- a/src/makefile
+++ b/src/makefile
@@ -31,7 +31,7 @@ build/commons/collections:
 	mkdir -p $@
 
 build/libcommons.so: build/commons/collections $(OBJS)
-	$(CC) -shared -o "$@" $(OBJS)
+	$(CC) -shared -o "$@" $(OBJS) -lcrypto
 
 build/%.o: %.c | $(DEPS)
 	$(CC) -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"

--- a/tests/integration-tests/logger/makefile
+++ b/tests/integration-tests/logger/makefile
@@ -19,7 +19,7 @@ create-dirs:
 	mkdir -p build/.
 
 $(BIN): dependents create-dirs $(OBJS)
-	$(CC) -L"../../../src/build" -o "$(BIN)" $(OBJS) -lcommons -lcrypto -lpthread
+	$(CC) -L"../../../src/build" -o "$(BIN)" $(OBJS) -lcommons -lpthread
 
 build/%.o: ./%.c
 	$(CC) -I"../../../src" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"

--- a/tests/integration-tests/temporal/makefile
+++ b/tests/integration-tests/temporal/makefile
@@ -19,7 +19,7 @@ create-dirs:
 	mkdir -p build/.
 
 $(BIN): dependents create-dirs $(OBJS)
-	$(CC) -L"../../../src/build" -o "$(BIN)" $(OBJS) -lcommons -lcrypto -lpthread
+	$(CC) -L"../../../src/build" -o "$(BIN)" $(OBJS) -lcommons -lpthread
 
 build/%.o: ./%.c
 	$(CC) -I"../../../src" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"

--- a/tests/unit-tests/makefile
+++ b/tests/unit-tests/makefile
@@ -8,30 +8,28 @@ COMMONS_BIN=$(COMMONS)/build
 COMMONS_SO=$(COMMONS_BIN)/libcommons.so
 COMMONS_SRCS=$(patsubst ./%,$(COMMONS)/%,$(shell make --no-print-directory -C $(COMMONS) sources))
 
-C_SRCS=$(shell find . -iname "*.c" | tr '\n' ' ')
-OBJS=$(C_SRCS:./%.c=build/%.o)
-DEPS=/usr/include/cspecs/cspec.h
+C_SRCS=$(wildcard *.c)
+OBJS=$(C_SRCS:%.c=build/%.o)
 
 BIN_DIR=build
 BIN=$(BIN_DIR)/commons-unit-test
+
+CSPEC_REPO=https://github.com/mumuki/cspec
+CSPEC_VERSION=043089d9c55871526f1d6728af4d0febdbe8c38a
+CSPEC=$(BIN_DIR)/cspec-$(CSPEC_VERSION)
+CSPEC_BIN=$(CSPEC)/release
+CSPEC_SO=$(CSPEC_BIN)/libcspecs.so
 
 all: $(BIN)
 
 $(BIN_DIR):
 	mkdir -p $@
 
-$(BIN): $(COMMONS_SO) $(BIN_DIR) $(OBJS)
-	$(CC) -L"$(COMMONS_BIN)" -o "$@" $(OBJS) -lcommons -lcrypto -lcspecs
+$(BIN): $(COMMONS_SO) $(OBJS) | $(BIN_DIR) $(CSPEC_SO)
+	$(CC) -L"$(COMMONS_BIN)" -L"$(CSPEC_BIN)" -o "$@" $(OBJS) -lcommons -lcspecs
 
-build/%.o: ./%.c | $(DEPS)
-	$(CC) -I"$(COMMONS)" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
-
-/usr/include/cspecs/%.h:
-	$(eval TMP := $(shell mktemp -d))
-	curl -fsSL "https://github.com/mumuki/cspec/archive/043089d9c55871526f1d6728af4d0febdbe8c38a.tar.gz" \
-		| tar -xzC $(TMP) --strip-components=1
-	$(MAKE) --no-print-directory -C $(TMP) install
-	$(RM) $(TMP)
+build/%.o: ./%.c $(CSPEC_SO) | $(BIN_DIR)
+	$(CC) -I"$(COMMONS)" -I"$(CSPEC)" -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 
 debug: CC += -DDEBUG -g
 debug: all
@@ -40,14 +38,18 @@ clean:
 	$(RM) build
 
 test: all
-	LD_LIBRARY_PATH="$(COMMONS_BIN)" ./$(BIN)
+	LD_LIBRARY_PATH="$(COMMONS_BIN):$(CSPEC_BIN)" ./$(BIN)
 
 $(COMMONS_SO): $(COMMONS_SRCS)
 	-cd $(COMMONS) && $(MAKE) all
 
+$(CSPEC_SO): $(CSPEC)
+	$(MAKE) -C $(CSPEC)
+
+$(CSPEC): | $(BIN_DIR)
+	curl -fsSL "$(CSPEC_REPO)/archive/$(CSPEC_VERSION).tar.gz" | tar -xzC $(BIN_DIR)
+
 valgrind: debug
-	LD_LIBRARY_PATH="$(COMMONS_BIN)" valgrind --error-exitcode=42 --leak-check=full -v ./$(BIN)
+	LD_LIBRARY_PATH="$(COMMONS_BIN):$(CSPEC_BIN)" valgrind --error-exitcode=42 --leak-check=full -v ./$(BIN)
 
 .PHONY: all debug clean test valgrind
-
-.PRECIOUS: $(DEPS)

--- a/tests/unit-tests/makefile
+++ b/tests/unit-tests/makefile
@@ -16,7 +16,7 @@ BIN=$(BIN_DIR)/commons-unit-test
 
 CSPEC_REPO=https://github.com/mumuki/cspec
 CSPEC_VERSION=043089d9c55871526f1d6728af4d0febdbe8c38a
-CSPEC=$(BIN_DIR)/cspec-$(CSPEC_VERSION)
+CSPEC=cspec
 CSPEC_BIN=$(CSPEC)/release
 CSPEC_SO=$(CSPEC_BIN)/libcspecs.so
 
@@ -44,10 +44,12 @@ $(COMMONS_SO): $(COMMONS_SRCS)
 	-cd $(COMMONS) && $(MAKE) all
 
 $(CSPEC_SO): $(CSPEC)
-	$(MAKE) -C $(CSPEC)
+	$(MAKE) -C "$<"
 
-$(CSPEC): | $(BIN_DIR)
-	curl -fsSL "$(CSPEC_REPO)/archive/$(CSPEC_VERSION).tar.gz" | tar -xzC $(BIN_DIR)
+$(CSPEC):
+	mkdir -p "$@"
+	curl -fsSL "$(CSPEC_REPO)/archive/$(CSPEC_VERSION).tar.gz" \
+		| tar -xzC "$@" --strip-components=1
 
 valgrind: debug
 	LD_LIBRARY_PATH="$(COMMONS_BIN):$(CSPEC_BIN)" valgrind --error-exitcode=42 --leak-check=full -v ./$(BIN)


### PR DESCRIPTION
1. Actualizo el makefile de los unit tests para que usen una versión local de CSpec en lugar de chequear que el paquete esté instalado (relates https://github.com/sisoputnfrba/foro/issues/4977)

2. Agrego `-lcrypto` al compilar las commons, así en teoría no haría falta agregarlo luego

3. Hago que el makefile falle temprano si hubo un problema al buildear, en vez de hacer que siga intentando correr los tests